### PR TITLE
Feature/317: Criteria Editor Validation

### DIFF
--- a/BridgeCareApp/BridgeCare/BridgeCare.csproj
+++ b/BridgeCareApp/BridgeCare/BridgeCare.csproj
@@ -346,6 +346,7 @@
     <Compile Include="Models\TargetModel.cs" />
     <Compile Include="Models\TargetParameters.cs" />
     <Compile Include="Models\UserInformationModel.cs" />
+    <Compile Include="Models\ValidateCriteriaModel.cs" />
     <Compile Include="Models\ValidateModel.cs" />
     <Compile Include="Models\YearlyBudgetAndCost.cs" />
     <Compile Include="Models\YearlyDataModel.cs" />

--- a/BridgeCareApp/BridgeCare/Controllers/ValidationController.cs
+++ b/BridgeCareApp/BridgeCare/Controllers/ValidationController.cs
@@ -43,12 +43,16 @@ namespace BridgeCare.Controllers
         [ModelValidation("Function call not valid")]
         [Route("api/ValidateCriteria")]
         [HttpPost]
-        public HttpResponseMessage ValidateCriteria([FromBody]string data)
+        public HttpResponseMessage ValidateCriteria([FromBody]ValidateCriteriaModel data)
         {
             try
             {
-                string numberHits = validate.ValidateCriteria(data, db);
+                string numberHits = validate.ValidateCriteria(data.Criteria, db);
                 return Request.CreateResponse(HttpStatusCode.OK, numberHits);
+            }
+            catch (InvalidOperationException ex)
+            {
+                return Request.CreateResponse(HttpStatusCode.OK, ex.Message);
             }
             catch (Exception ex)
             {

--- a/BridgeCareApp/BridgeCare/DataAccessLayer/CommittedDAL.cs
+++ b/BridgeCareApp/BridgeCare/DataAccessLayer/CommittedDAL.cs
@@ -4,6 +4,7 @@ using BridgeCare.Interfaces;
 using BridgeCare.Models;
 using System;
 using System.Collections.Generic;
+using System.Data.Entity;
 using System.Data.SqlClient;
 using System.Linq;
 
@@ -76,14 +77,9 @@ namespace BridgeCare.DataAccessLayer
         /// <param name="simulationId"></param>
         /// <param name="db"></param>
         /// <returns></returns>
-        public List<COMMITTED_> GetCommittedProjects(int simulationId, BridgeCareContext db)
+        public List<CommittedEntity> GetCommittedProjects(int simulationId, BridgeCareContext db)
         {
-            return db.COMMITTEDPROJECTs.Include("COMMIT_CONSEQUENCES").Where(c => c.SIMULATIONID == simulationId).ToList();
-        }
-
-        private COMMITTED_ CreateCommitted(CommittedProjectModel committedProjectModel)
-        {
-            return new COMMITTED_(committedProjectModel.SimulationId, committedProjectModel.SectionId, committedProjectModel.Years, committedProjectModel.TreatmentName, committedProjectModel.YearSame, committedProjectModel.YearAny, committedProjectModel.Budget, committedProjectModel.Cost);
+            return db.CommittedProjects.Include(committedProject => committedProject.COMMIT_CONSEQUENCES).Where(c => c.SIMULATIONID == simulationId).ToList();
         }
     }
 }

--- a/BridgeCareApp/BridgeCare/Interfaces/ICommitted.cs
+++ b/BridgeCareApp/BridgeCare/Interfaces/ICommitted.cs
@@ -8,6 +8,6 @@ namespace BridgeCare.Interfaces
     {
         void SaveCommittedProjects(List<CommittedProjectModel> committedProjectModels, BridgeCareContext db);
 
-        List<COMMITTED_> GetCommittedProjects(int simulationId, BridgeCareContext db);
+        List<CommittedEntity> GetCommittedProjects(int simulationId, BridgeCareContext db);
     }
 }

--- a/BridgeCareApp/BridgeCare/Models/ValidateCriteriaModel.cs
+++ b/BridgeCareApp/BridgeCare/Models/ValidateCriteriaModel.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace BridgeCare.Models
+{
+    public class ValidateCriteriaModel
+    {
+        public string Criteria { get; set; }
+    }
+}

--- a/BridgeCareApp/BridgeCare/Services/CommittedProjects.cs
+++ b/BridgeCareApp/BridgeCare/Services/CommittedProjects.cs
@@ -61,7 +61,7 @@ namespace BridgeCare.Services
             }
         }
 
-        private void AddDataCells(ExcelWorksheet worksheet, List<COMMITTED_> committedProjects, int networkId, BridgeCareContext db)
+        private void AddDataCells(ExcelWorksheet worksheet, List<CommittedEntity> committedProjects, int networkId, BridgeCareContext db)
         {            
             var networkModel = new NetworkModel { NetworkId = networkId };
             var sectionModels = sections.GetSections(networkModel, db).ToList();
@@ -92,7 +92,7 @@ namespace BridgeCare.Services
             }
         }
 
-        private void AddHeaderCells(ExcelWorksheet worksheet, List<COMMIT_CONSEQUENCES> commitConsequences)
+        private void AddHeaderCells(ExcelWorksheet worksheet, List<CommitConsequencesEntity> commitConsequences)
         {
             var fixColumnHeaders = new List<string>() { "BRKEY", "BMSID", "TREATMENT", "YEAR", "YEARANY", "YEARSAME", "BUDGET", "COST", "AREA" };
             int headerRow = 1;

--- a/BridgeCareApp/BridgeCareNodeApp/config/express.js
+++ b/BridgeCareApp/BridgeCareNodeApp/config/express.js
@@ -8,6 +8,6 @@ module.exports = function (app) {
     app.use(compression());
 
     app.use(cors());
-    app.use(bodyParser.urlencoded({ extended: true }));
-    app.use(bodyParser.json());
+    app.use(bodyParser.urlencoded({ limit: '10mb', extended: true }));
+    app.use(bodyParser.json({limit: '10mb', extended: true}));
 };

--- a/BridgeCareApp/VuejsApp/src/services/criteria-editor.service.ts
+++ b/BridgeCareApp/VuejsApp/src/services/criteria-editor.service.ts
@@ -1,0 +1,13 @@
+import {AxiosPromise} from 'axios';
+import {axiosInstance} from '@/shared/utils/axios-instance';
+import {CriteriaValidation} from '@/shared/models/iAM/criteria-validation';
+
+export default class CriteriaEditorService {
+    /**
+     * Checks a criteria's validity
+     * @param criteria Criteria string to validate
+     */
+    static checkCriteriaValidity(criteriaValidation: CriteriaValidation): AxiosPromise {
+        return axiosInstance.post('/api/ValidateCriteria', criteriaValidation);
+    }
+}

--- a/BridgeCareApp/VuejsApp/src/shared/modals/EquationEditorDialog.vue
+++ b/BridgeCareApp/VuejsApp/src/shared/modals/EquationEditorDialog.vue
@@ -129,9 +129,7 @@
     import {EquationEditorDialogResult} from '@/shared/models/modals/equation-editor-dialog-result';
     import EquationEditorService from '@/services/equation-editor.service';
     import {formulas} from '@/shared/utils/formulas';
-    import {isEmpty} from 'ramda';
     import {AxiosResponse} from 'axios';
-    import {http2XX, setStatusMessage} from '@/shared/utils/http-utils';
     import {getPropertyValues} from '@/shared/utils/getter-utils';
     import {Attribute} from '@/shared/models/iAM/attribute';
     import {hasValue} from '@/shared/utils/has-value-util';
@@ -306,8 +304,8 @@
                         this.cannotSubmit = false;
                         this.showInvalidMessage = false;
                     } else {
-                        // if result is false then set showInvalidMessage = true, cannotSubmit = true, & showValidMessage = false
                         this.invalidMessage = response.data;
+                        // if result is false then set showInvalidMessage = true, cannotSubmit = true, & showValidMessage = false
                         this.showInvalidMessage = true;
                         this.cannotSubmit = true;
                         this.showValidMessage = false;

--- a/BridgeCareApp/VuejsApp/src/shared/models/iAM/criteria-validation.ts
+++ b/BridgeCareApp/VuejsApp/src/shared/models/iAM/criteria-validation.ts
@@ -1,0 +1,3 @@
+export interface CriteriaValidation {
+    criteria: string;
+}


### PR DESCRIPTION
-added a criteria-editor.service.ts to hook into validation api
-added check/submit logic to criteria editor
-updated validation api to return an OK response but with the validation error if a criteria is invalid to prevent triggering the axios error interceptor
-fixed committed entity references
-increased size of allowed payloads for nodejs