### PR TITLE
Bug/346: Parameterize Raw Queries => AttributeByYearDAL.cs

### DIFF
--- a/BridgeCareApp/BridgeCare/DataAccessLayer/AttributesByYearDAL.cs
+++ b/BridgeCareApp/BridgeCare/DataAccessLayer/AttributesByYearDAL.cs
@@ -73,7 +73,14 @@ namespace BridgeCare.DataAccessLayer
                 sqlCommand.Parameters.Add(sectionIdParameter);
                 // create a data table from the reader
                 var queryReturnValues = new DataTable();
-                queryReturnValues.Load(sqlCommand.ExecuteReader());
+                // create data reader from sql command
+                var dataReader = sqlCommand.ExecuteReader();
+                // use the data reader to load the data table
+                queryReturnValues.Load(dataReader);
+                // close the data reader
+                dataReader.Close();
+                // close the connection
+                connection.Close();
                 // create the attributes list and return
                 return DataTableToAttributeList(queryReturnValues);
             }

--- a/BridgeCareApp/BridgeCare/Models/AttributeByYearModel.cs
+++ b/BridgeCareApp/BridgeCare/Models/AttributeByYearModel.cs
@@ -4,12 +4,12 @@ namespace BridgeCare.Models
 {
     public class AttributeByYearModel
     {
+        public string Name { get; set; }
+        public List<AttributeYearlyValueModel> YearlyValues { get; set; }
+
         public AttributeByYearModel()
         {
             YearlyValues = new List<AttributeYearlyValueModel>();
         }
-
-        public string Name { get; set; }
-        public List<AttributeYearlyValueModel> YearlyValues { get; set; }
     }
 }


### PR DESCRIPTION
--renamed selectStatement to query, added 2nd parameter (SqlParameter, sectionIdParameter)
--added SqlCommand functionality; DataTable Load() function uses SqlDataReader returned by SqlCommand ExecuteReader() to create a DataTable
-modified the query strings in GetProjectedAttributes & GeneralAttributeValueQuery with parameters and added a sectionIdParameter SqlParameter for each
-coding best practice (movied AttributeByYearModel properties to top of class definition