### PR TITLE
Bug/413: Remaining Life Limit Save Data to UI Fix

### DIFF
--- a/BridgeCareApp/BridgeCare/DataAccessLayer/RemainingLifeLimitDAL.cs
+++ b/BridgeCareApp/BridgeCare/DataAccessLayer/RemainingLifeLimitDAL.cs
@@ -76,17 +76,17 @@ namespace BridgeCare.DataAccessLayer
                                 RemainingLifeLimitsEntity.DeleteEntry(remainingLifeLimit, db);
                             }
                         });
-                        // check for models that didn't have a remaining life limit record match
-                        if (data.RemainingLifeLimits.Any(model => !model.matched))
-                        {
-                            // create new remaining life limits from the unmatched models' data
-                            db.RemainingLifeLimits
-                                .AddRange(data.RemainingLifeLimits
-                                    .Where(model => !model.matched)
-                                    .Select(model => new RemainingLifeLimitsEntity(simulationId, model))
-                                    .ToList()
-                                );
-                        }
+                    }
+                    // check for models that didn't have a remaining life limit record match
+                    if (data.RemainingLifeLimits.Any(model => !model.matched))
+                    {
+                        // create new remaining life limits from the unmatched models' data
+                        db.RemainingLifeLimits
+                            .AddRange(data.RemainingLifeLimits
+                                .Where(model => !model.matched)
+                                .Select(model => new RemainingLifeLimitsEntity(simulationId, model))
+                                .ToList()
+                            );
                     }
                     // save all changes
                     db.SaveChanges();


### PR DESCRIPTION
-moved a logic block that saved new remaining life limit data if there was no matching data already found to be existing (caused new data not to be saved when there was no existing data found to begin with)