### PR TITLE
Feature/369: Disable Summary Report and Show Missing Attributes

### DIFF
--- a/BridgeCareApp/BridgeCare/Controllers/SummaryReportController.cs
+++ b/BridgeCareApp/BridgeCare/Controllers/SummaryReportController.cs
@@ -1,21 +1,41 @@
 ﻿using BridgeCare.Interfaces;
 using BridgeCare.Models;
 using System;
+using System.Data.SqlClient;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Web.Http;
 using System.Web.Http.Filters;
+using BridgeCare.ApplicationLog;
 
 namespace BridgeCare.Controllers
 {
     public class SummaryReportController : ApiController
     {
         private readonly ISummaryReportGenerator summaryReportGenerator;
+        private readonly IBridgeData bridgeData;
+        private readonly BridgeCareContext db;
 
-        public SummaryReportController(ISummaryReportGenerator summaryReportGenerator)
+        public SummaryReportController(ISummaryReportGenerator summaryReportGenerator, IBridgeData bridgeDataInterface, BridgeCareContext context)
         {
             this.summaryReportGenerator = summaryReportGenerator;
+            this.bridgeData = bridgeDataInterface;
+            this.db = context;
+        }
+
+        [HttpGet]
+        [Route("api/GetSummaryReportMissingAttributes")]
+        public IHttpActionResult GetSummaryReportMissingAttributes(int simulationId, int networkId)
+        {
+            try
+            {
+                return Ok(bridgeData.GetSummaryReportMissingAttributes(simulationId, networkId, db));
+            }
+            catch (Exception ex)
+            {
+                return InternalServerError(ex);
+            }
         }
 
         // POST: api/SummaryReport

--- a/BridgeCareApp/BridgeCare/Interfaces/SummaryReport/IBridgeData.cs
+++ b/BridgeCareApp/BridgeCare/Interfaces/SummaryReport/IBridgeData.cs
@@ -14,5 +14,7 @@ namespace BridgeCare.Interfaces
         DataTable GetSimulationData(SimulationModel simulationModel, BridgeCareContext dbContext, List<int> simulationYears);
 
         IQueryable<ReportProjectCost> GetReportData(SimulationModel simulationModel, BridgeCareContext dbContext, List<int> simulationYears);
+
+        List<string> GetSummaryReportMissingAttributes(int simulationId, int networkId, BridgeCareContext db);
     }
 }

--- a/BridgeCareApp/VuejsApp/src/components/scenarios/Scenarios.vue
+++ b/BridgeCareApp/VuejsApp/src/components/scenarios/Scenarios.vue
@@ -158,6 +158,7 @@
         @Action('createScenario') createScenarioAction: any;
         @Action('deleteScenario') deleteScenarioAction: any;
         @Action('updateScenario') updateScenarioAction: any;
+        @Action('getSummaryReportMissingAttributes') getSummaryReportMissingAttributesAction: any;
 
         alertData: AlertData = clone(emptyAlertData);
         alertBeforeDelete: AlertData = clone(emptyAlertData);
@@ -317,10 +318,16 @@
          * @param scenario Scenario object to use for setting the ReportsDownloaderDialogData object
          */
         onShowReportsDownloaderDialog(scenario: Scenario) {
-            this.reportsDownloaderDialogData = {
-                showModal: true,
-                scenario: scenario
-            };
+            this.getSummaryReportMissingAttributesAction({
+                selectedScenarioId: scenario.simulationId, selectedNetworkId: this.networks[0].networkId}
+            ).then(() => {
+                setTimeout(() => {
+                    this.reportsDownloaderDialogData = {
+                        showModal: true,
+                        scenario: scenario
+                    };
+                });
+            });
         }
 
         onCreateScenario() {

--- a/BridgeCareApp/VuejsApp/src/components/scenarios/scenarios-dialogs/ReportsDownloaderDialog.vue
+++ b/BridgeCareApp/VuejsApp/src/components/scenarios/scenarios-dialogs/ReportsDownloaderDialog.vue
@@ -1,5 +1,5 @@
 ﻿<template>
-    <v-dialog v-model="dialogData.showModal" persistent scrollable max-width="600px">
+    <v-dialog v-model="dialogData.showModal" persistent scrollable max-width="500px">
         <v-card>
             <v-card-title primary-title>
                 <v-layout column>
@@ -15,12 +15,37 @@
             <v-divider></v-divider>
             <v-card-text>
                 <v-list-tile v-for="item in reports" :key="item" avatar :disabled="isBusy">
-                    <v-list-tile-content>
-                        <v-list-tile-title>{{item}}</v-list-tile-title>
-                    </v-list-tile-content>
-                    <v-list-tile-action>
-                        <v-checkbox :value="item" color="primary lighten-1" v-model="selectedReports"></v-checkbox>
-                    </v-list-tile-action>
+                    <v-layout align-start row v-if="item === 'Summary Report'">
+                        <v-flex xs4>
+                            <v-checkbox :value="item" :label="item" color="primary lighten-1" v-model="selectedReports"
+                                        :disabled="showMissingAttributesMessage">
+                            </v-checkbox>
+                        </v-flex>
+                        <v-flex xs1>
+                            <v-menu v-if="showMissingAttributesMessage" top>
+                                <template slot="activator">
+                                    <v-btn icon class="ara-dark-gray"><v-icon>fas fa-info-circle</v-icon></v-btn>
+                                </template>
+                                <v-card>
+                                    <v-card-text class="missing-attributes-card-text">
+                                        <v-list>
+                                            <v-subheader>MISSING SCENARIO ATTRIBUTES</v-subheader>
+                                            <v-list-tile v-for="attribute in missingSummaryReportAttributes" :key="attribute">
+                                                <v-list-tile-content>
+                                                    <v-list-tile-title>{{attribute}}</v-list-tile-title>
+                                                </v-list-tile-content>
+                                            </v-list-tile>
+                                        </v-list>
+                                    </v-card-text>
+                                </v-card>
+                            </v-menu>
+                        </v-flex>
+                        <v-spacer></v-spacer>
+                    </v-layout>
+                    <v-layout align-start row v-else>
+                        <v-checkbox :value="item" :label="item" color="primary lighten-1" v-model="selectedReports">
+                        </v-checkbox>
+                    </v-layout>
                 </v-list-tile>
                 <v-alert :value="showError" color="error" icon="warning" outline>{{errorMessage}}</v-alert>
             </v-card-text>
@@ -49,6 +74,7 @@
     import {AxiosResponse} from 'axios';
     import {emptyScenario, Scenario} from '@/shared/models/iAM/scenario';
     import {clone} from 'ramda';
+    import {hasValue} from '@/shared/utils/has-value-util';
 
     @Component({
     })
@@ -56,6 +82,7 @@
         @Prop() dialogData: ReportsDownloaderDialogData;
 
         @State(state => state.busy.isBusy) isBusy: boolean;
+        @State(state => state.scenario.missingSummaryReportAttributes) missingSummaryReportAttributes: string[];
 
         @Action('setErrorMessage') setErrorMessageAction: any;
 
@@ -64,6 +91,7 @@
         selectedReports: string[] = [];
         errorMessage: string = '';
         showError: boolean = false;
+        showMissingAttributesMessage: boolean = false;
 
         @Watch('dialogData.showModal')
         onshowModalChanged(showModal: boolean) {
@@ -77,6 +105,11 @@
                 this.selectedReports = [];
             }
 
+        }
+
+        @Watch('missingSummaryReportAttributes')
+        onMissingSummaryReportAttributesChanged() {
+            this.showMissingAttributesMessage = hasValue(this.missingSummaryReportAttributes);
         }
 
         async onDownload(download: boolean) {
@@ -111,3 +144,11 @@
         }
     }
 </script>
+
+<style>
+    .missing-attributes-card-text {
+        max-height: 300px;
+        max-width: 300px;
+        overflow-y: auto;
+    }
+</style>

--- a/BridgeCareApp/VuejsApp/src/services/reports.service.ts
+++ b/BridgeCareApp/VuejsApp/src/services/reports.service.ts
@@ -18,4 +18,9 @@ export default class ReportsService {
     static getSummaryReport(selectedScenarioData: Scenario): AxiosPromise {
         return axiosInstance.post('/api/SummaryReport', selectedScenarioData, {responseType: 'blob'});
     }
+
+    static getSummaryReportMissingAttributes(selectedScenarioId: number, selectedNetworkId: number) {
+        return axiosInstance
+            .get(`/api/GetSummaryReportMissingAttributes?simulationId=${selectedScenarioId}&networkId=${selectedNetworkId}`);
+    }
 }

--- a/BridgeCareApp/VuejsApp/src/store-modules/scenario.module.ts
+++ b/BridgeCareApp/VuejsApp/src/store-modules/scenario.module.ts
@@ -6,6 +6,7 @@ import {hasValue} from '@/shared/utils/has-value-util';
 import {http2XX} from '@/shared/utils/http-utils';
 import prepend from 'ramda/es/prepend';
 import AnalysisEditorService from '@/services/analysis-editor.service';
+import ReportsService from '@/services/reports.service';
 
 const convertFromMongoToVueModel = (data: any) => {
     const scenarios: any = {
@@ -21,7 +22,8 @@ const state = {
     scenarios: [] as Scenario[],
     benefitAttributes: [] as string[],
     selectedScenarioName: '',
-    analysis: clone(emptyAnalysis) as Analysis
+    analysis: clone(emptyAnalysis) as Analysis,
+    missingSummaryReportAttributes: [] as string[]
 };
 
 const mutations = {
@@ -51,6 +53,9 @@ const mutations = {
     },
     analysisMutator(state: any, analysis: Analysis) {
         state.analysis = clone(analysis);
+    },
+    missingSummaryReportAttributesMutator(state: any, missingAttributes: string[]) {
+        state.missingSummaryReportAttributes = clone(missingAttributes);
     }
 };
 
@@ -146,6 +151,12 @@ const actions = {
                     commit('analysisMutator', payload.scenarioAnalysisData);
                     dispatch('setSuccessMessage', {message: 'Successfully saved scenario analysis'});
                 }
+            });
+    },
+    async getSummaryReportMissingAttributes({commit}: any, payload: any) {
+        await ReportsService.getSummaryReportMissingAttributes(payload.selectedScenarioId, payload.selectedNetworkId)
+            .then((response: AxiosResponse<any[]>) => {
+                commit('missingSummaryReportAttributesMutator', response.data);
             });
     }
 };


### PR DESCRIPTION
-added an API endpoint that will query the simulation table for a selected scenario to get all the columns in the simulation table and return any required attributes that were not returned (missing in the table)
-added call to api endpoint to find any missing required attributes before showing the report download dialog and disabling teh summary report option if there are missing attributes