### PR TITLE
473: Fix MongoDB Scenario Delete Functionality

### DIFF
--- a/BridgeCareApp/BridgeCare/DataAccessLayer/SimulationDAL.cs
+++ b/BridgeCareApp/BridgeCare/DataAccessLayer/SimulationDAL.cs
@@ -59,18 +59,18 @@ namespace BridgeCare.DataAccessLayer
             db.Entry(simulation).State = EntityState.Deleted;
             db.SaveChanges();
 
-            var connection = new SqlConnection(db.Database.Connection.ConnectionString);
-            connection.Open();
-
-            var dropQuery = $"IF OBJECT_ID ( 'SIMULATION_{simulation.NETWORKID}_{id}_0' , 'U' )  IS NOT NULL DROP TABLE SIMULATION_{simulation.NETWORKID}_{id} " +
-                            $"IF OBJECT_ID ( 'REPORT_{simulation.NETWORKID}_{id}' , 'U' )  IS NOT NULL DROP TABLE REPORT_{simulation.NETWORKID}_{id} " +
-                            $"IF OBJECT_ID ( 'BENEFITCOST_{simulation.NETWORKID}_{id}' , 'U' )  IS NOT NULL DROP TABLE BENEFITCOST_{simulation.NETWORKID}_{id} " +
-                            $"IF OBJECT_ID ( 'TARGET_{simulation.NETWORKID}_{id}' , 'U' )  IS NOT NULL DROP TABLE TARGET_{simulation.NETWORKID}_{id} ";
-
-            var cmd = new SqlCommand(dropQuery, connection) {CommandType = CommandType.Text};
-            cmd.ExecuteNonQuery();
-
-            connection.Close();
+            using (var connection = new SqlConnection(db.Database.Connection.ConnectionString))
+            {
+                connection.Open();
+                var dropQuery = $"IF OBJECT_ID ( 'SIMULATION_{simulation.NETWORKID}_{id}_0' , 'U' )  IS NOT NULL DROP TABLE SIMULATION_{simulation.NETWORKID}_{id} " +
+                                $"IF OBJECT_ID ( 'REPORT_{simulation.NETWORKID}_{id}' , 'U' )  IS NOT NULL DROP TABLE REPORT_{simulation.NETWORKID}_{id} " +
+                                $"IF OBJECT_ID ( 'BENEFITCOST_{simulation.NETWORKID}_{id}' , 'U' )  IS NOT NULL DROP TABLE BENEFITCOST_{simulation.NETWORKID}_{id} " +
+                                $"IF OBJECT_ID ( 'TARGET_{simulation.NETWORKID}_{id}' , 'U' )  IS NOT NULL DROP TABLE TARGET_{simulation.NETWORKID}_{id} ";
+                using (var command = new SqlCommand(dropQuery, connection) { CommandType = CommandType.Text })
+                {
+                    command.ExecuteNonQuery();
+                }
+            }
         }
 
         public SimulationModel CreateSimulation(CreateSimulationDataModel model, BridgeCareContext db)

--- a/BridgeCareApp/BridgeCareNodeApp/controllers/scenarioController.js
+++ b/BridgeCareApp/BridgeCareNodeApp/controllers/scenarioController.js
@@ -64,23 +64,17 @@ function scenarioController(Scenario) {
     }
 
     function deleteScenario(req, res) {
-        Scenario.findOneAndDelete({_id: req.params.scenarioId})
-            .then(scenario => {
-                if(!scenario) {
-                    return res.status(404).send({
-                        message: `Scenario not found with id ${req.params.scenarioId}`
-                    });
-                }
-                res.status(200);
-            })
-            .catch(err => {
-                if(err.name === 'NotFound'){
-                    return res.status(404).send({
-                        message: `Scenario not found with Id ${req.params.scenarioId}`
-                    });
-                }
-                return res.status(500)
-            });
+        Scenario.deleteOne({_id: req.params.scenarioId}, (err, result) => {
+            if (err) {
+                return res.status(500).json(err);
+            }
+
+            if (result.deletedCount === 1) {
+                return res.status(200).json(result);
+            } else {
+                return res.status(404).json({message: 'Scenario not found'});
+            }
+        });
     }
 
     return { post, get, deleteScenario, put, postMultipleScenarios};

--- a/BridgeCareApp/BridgeCareNodeApp/routes/scenarioRouters.js
+++ b/BridgeCareApp/BridgeCareNodeApp/routes/scenarioRouters.js
@@ -1,7 +1,7 @@
 const express = require('express');
 const scenarioController = require('../controllers/scenarioController');
 
-function routes(Scenario){
+function scenarioRoutes(Scenario){
     const scenarioRouter = express.Router();
     const controller = scenarioController(Scenario);
       scenarioRouter.route("/GetMongoScenarios")
@@ -20,4 +20,4 @@ function routes(Scenario){
         return scenarioRouter;
 }
 
-module.exports = routes;
+module.exports = scenarioRoutes;


### PR DESCRIPTION
-modified nodejs scenario delete function to use the mongo db deleteOne collection method and return the results to eliminate the axios http request hang up
-modified API scenario delete functionality to use a 'using' statement to ensure correct use of disposable objects
-renamed nodejs scenario routes from 'routes' to 'scenarioRoutes'
-updated deleteScenario and scenario socket module actions: use payload provided identifiers in deleteScenario action; added more user friendly info message when delete occurs from another source