### PR TITLE
vnext/447: Currency Formatting

### DIFF
--- a/BridgeCareApp/BridgeCareNodeApp/app.js
+++ b/BridgeCareApp/BridgeCareNodeApp/app.js
@@ -80,10 +80,3 @@ async function run() {
       networkRouter
   ]);
 }
-
-
-
-
-
-
-

--- a/BridgeCareApp/VuejsApp/src/components/investment-editor/InvestmentEditor.vue
+++ b/BridgeCareApp/VuejsApp/src/components/investment-editor/InvestmentEditor.vue
@@ -71,7 +71,7 @@
                                         <v-edit-dialog :return-value.sync="props.item[header.value]"
                                                        large lazy persistent
                                                        @save="onEditBudgetYearAmount(props.item.year, header.value, props.item[header.value])">
-                                            {{props.item[header.value]}}
+                                            {{formatAsCurrency(props.item[header.value])}}
                                             <template slot="input">
                                                 <v-text-field v-model="props.item[header.value]"
                                                               label="Edit" single-line>
@@ -159,7 +159,8 @@
     import { getLatestPropertyValue, getPropertyValues } from '@/shared/utils/getter-utils';
     import { sortByProperty, sorter } from '@/shared/utils/sorter-utils';
     import { EditedBudget } from '@/shared/models/modals/edit-budgets-dialog';
-    import { CriteriaDrivenBudgets } from '../../shared/models/iAM/criteria-driven-budgets';
+    import { CriteriaDrivenBudgets } from '@/shared/models/iAM/criteria-driven-budgets';
+    import {formatAsCurrency} from '@/shared/utils/currency-formatter';
     const ObjectID = require('bson-objectid');
 
     @Component({
@@ -715,6 +716,14 @@
                     this.getScenarioInvestmentLibraryAction({ selectedScenarioId: this.selectedScenarioId });
                 });
             }
+        }
+
+        /**
+         * Formats a value as currency by calling the formatAsCurrency utility function
+         * @param value Value to format
+         */
+        formatAsCurrency(value: any) {
+            return formatAsCurrency(value);
         }
     }
 </script>

--- a/BridgeCareApp/VuejsApp/src/shared/utils/currency-formatter.ts
+++ b/BridgeCareApp/VuejsApp/src/shared/utils/currency-formatter.ts
@@ -1,0 +1,9 @@
+export const formatAsCurrency = (value: any) => {
+    if (isNaN(value)) {
+        return value;
+    }
+    
+    return new Intl
+        .NumberFormat('en-US', {style: 'currency', currency: 'USD'})
+        .format(value);
+};


### PR DESCRIPTION
-added a formatAsCurrency utility function that will format any number|string values that are numbers (isNaN=false) as us dollars
-updated investment editor so all budget amounts use the formatAsCurrency utility for the output