### PR TITLE
vnext/514: Store user auth info in client localStorage

### DIFF
--- a/BridgeCareApp/VuejsApp/src/components/Authentication.vue
+++ b/BridgeCareApp/VuejsApp/src/components/Authentication.vue
@@ -18,10 +18,13 @@
     import Vue from 'vue';
     import {Component, Watch} from 'vue-property-decorator';
     import {State, Action} from 'vuex-class';
+    import AuthenticationService from '@/services/authentication.service';
+    import {AxiosResponse} from 'axios';
+    import {http2XX} from '@/shared/utils/http-utils';
 
     @Component
     export default class Authentication extends Vue {
-        @State(state => state.authentication.loginFailed) loginFailed: boolean;
+        @State(state => state.authentication.authenticated) authenticated: boolean;
 
         @Action('setSuccessMessage') setSuccessMessageAction: any;
         @Action('setErrorMessage') setErrorMessageAction: any;
@@ -30,9 +33,9 @@
         @Action('getNetworks') getNetworksAction: any;
         @Action('getAttributes') getAttributesAction: any;
 
-        @Watch('loginFailed')
+        @Watch('authenticated')
         onLoginChange() {
-            if (this.loginFailed) {
+            if (!this.authenticated) {
                 this.onAuthenticationFailure();
             } else {
                 this.setSuccessMessageAction({message: 'Authentication successful.'});
@@ -54,9 +57,9 @@
                 window.location.href = `http://localhost:8080/Authentication/?code=${code}`;
                 return;
             }
-            
+
             this.getUserTokensAction(code).then(() => {
-                if (this.loginFailed) {
+                if (!this.authenticated) {
                     this.onAuthenticationFailure();
                 } else {
                     this.getUserInfoAction();

--- a/BridgeCareApp/VuejsApp/src/components/AuthenticationStart.vue
+++ b/BridgeCareApp/VuejsApp/src/components/AuthenticationStart.vue
@@ -28,10 +28,10 @@
 
     @Component
     export default class AuthenticationStart extends Vue {
-        @State(state => state.authentication.loginFailed) loginFailed: boolean;
+        @State(state => state.authentication.authenticated) authenticated: boolean;
 
         onRedirect() {
-            if (this.loginFailed) {
+            if (!this.authenticated) {
                 var href: string = `${oidcConfig.authorizationEndpoint}?response_type=code&scope=openid&scope=BAMS`;
                 href += `&client_id=${oidcConfig.clientId}`;
                 href += `&redirect_uri=${oidcConfig.redirectUri}`;

--- a/BridgeCareApp/VuejsApp/src/components/LandingPage.vue
+++ b/BridgeCareApp/VuejsApp/src/components/LandingPage.vue
@@ -1,0 +1,9 @@
+<template></template>
+
+<script lang="ts">
+    import Vue from 'vue';
+    import Component from 'vue-class-component';
+
+    @Component
+    export default class LandingPage extends Vue {}
+</script>

--- a/BridgeCareApp/VuejsApp/src/router.ts
+++ b/BridgeCareApp/VuejsApp/src/router.ts
@@ -5,6 +5,7 @@ import Inventory from '@/components/Inventory.vue';
 import EditAnalysis from '@/components/scenarios/EditAnalysis.vue';
 import UnderConstruction from '@/components/UnderConstruction.vue';
 import RemainingLifeLimitEditor from '@/components/remaining-life-limit-editor/RemainingLifeLimitEditor.vue';
+import LandingPage from '@/components/LandingPage.vue';
 
 const Scenario = () => import(/* webpackChunkName: "scenario" */ '@/components/scenarios/Scenarios.vue');
 const EditScenario = () => import(/* webpackChunkName: "editScenario" */ '@/components/scenarios/EditScenario.vue');
@@ -141,6 +142,11 @@ const router = new VueRouter({
             path: '/UnderConstruction/',
             name: 'UnderConstruction',
             component: UnderConstruction
+        },
+        {
+            path: '/iAM/',
+            name: 'iAM',
+            component: LandingPage
         },
         {
             path: '*',

--- a/BridgeCareApp/VuejsApp/src/shared/models/iAM/authentication.ts
+++ b/BridgeCareApp/VuejsApp/src/shared/models/iAM/authentication.ts
@@ -1,0 +1,13 @@
+export interface UserTokens {
+    access_token: string;
+    refresh_token: string;
+    id_token: string;
+    expires_in: number;
+    token_type: string;
+}
+
+export interface UserInfo {
+    sub: string;
+    roles: string;
+    email: string;
+}

--- a/BridgeCareApp/VuejsApp/src/shared/models/iAM/user-information.ts
+++ b/BridgeCareApp/VuejsApp/src/shared/models/iAM/user-information.ts
@@ -1,4 +1,0 @@
-export interface UserInformation {
-    name: string;
-    id: string;
-}

--- a/BridgeCareApp/VuejsApp/src/shared/utils/authorization-header.ts
+++ b/BridgeCareApp/VuejsApp/src/shared/utils/authorization-header.ts
@@ -1,8 +1,12 @@
 import store from '@/store/root-store';
+import {UserTokens} from '@/shared/models/iAM/authentication';
 
 /**
  * Creates a header to send with all calls to the C# api
  */
 export const getAuthorizationHeader = () => {
-    return {'Authorization': 'Bearer ' + (store.state as any).authentication.userAccessToken};
+    if (localStorage.getItem('UserTokens')) {
+        const userTokens: UserTokens = JSON.parse(localStorage.getItem('UserTokens') as string) as UserTokens;
+        return {'Authorization': `Bearer ${userTokens.access_token}`};
+    }
 };

--- a/BridgeCareApp/VuejsApp/src/store-modules/authentication.module.ts
+++ b/BridgeCareApp/VuejsApp/src/store-modules/authentication.module.ts
@@ -1,80 +1,82 @@
 import AuthenticationService from '../services/authentication.service';
 import {AxiosResponse} from 'axios';
-import {UserInformation} from '@/shared/models/iAM/user-information';
-import {hasValue} from '@/shared/utils/has-value-util';
-import {axiosInstance} from '@/shared/utils/axios-instance';
+import {UserInfo, UserTokens} from '@/shared/models/iAM/authentication';
+import {http2XX} from '@/shared/utils/http-utils';
 
 const state = {
-    loginFailed: true,
-    userName: '',
-    userId: '',
-    userAccessToken: '',
-    userRefreshToken: '',
-    userIdToken: '',
-    userRoles: [] as Array<string>
+    authenticated: false,
+    username: ''
 };
 
 const mutations = {
-    loginMutator(state: any, status: boolean) {
-        state.loginFailed = status;
+    authenticatedMutator(state: any, status: boolean) {
+        state.authenticated = status;
     },
-    userNameMutator(state: any, userName: string) {
-        state.userName = userName;
-    },
-    userIdMutator(state: any, userId: string) {
-        state.userId = userId;
-    },
-    userIdTokenMutator(state: any, userIdToken: string) {
-        state.userIdToken = userIdToken;
-    },
-    userAccessTokenMutator(state: any, userAccessToken: string) {
-        state.userAccessToken = userAccessToken;
-    },
-    userRefreshTokenMutator(state: any, userRefreshToken: string) {
-        state.userRefreshToken = userRefreshToken;
+    usernameMutator(state: any, username: string) {
+        state.username = username;
     }
 };
 
 const actions = {
     async getUserTokens({commit}: any, code: string) {
-        return await AuthenticationService.getUserTokens(code)
-        .then((response: AxiosResponse<string>) => {
-            const jsonResponse: any = JSON.parse(response.data);
-            commit('loginMutator', false);
-            commit('userIdTokenMutator', jsonResponse.id_token);
-            commit('userAccessTokenMutator', jsonResponse.access_token);
-            commit('userRefreshTokenMutator', jsonResponse.refresh_token);
-        });
+        await AuthenticationService.getUserTokens(code)
+            .then((response: AxiosResponse<string>) => {
+                if (http2XX.test(response.status.toString())) {
+                    localStorage.setItem('UserTokens', response.data);
+                    commit('authenticatedMutator', true);
+                }
+            });
     },
 
-    async refreshAccessToken({commit}: any) {
-        return await AuthenticationService.refreshAccessToken(state.userRefreshToken)
-        .then((response: AxiosResponse<string>) => {
-            const jsonResponse: any = JSON.parse(response.data);
-            commit('userAccessTokenMutator', jsonResponse.access_token);
-            commit('userRefreshTokenMutator', jsonResponse.refresh_token);
-        });
+    async refreshAccessToken({commit, dispatch}: any) {
+        if (!localStorage.getItem('UserTokens')) {
+            dispatch('logOut');
+        } else {
+            const userTokens: UserTokens = JSON.parse(localStorage.getItem('UserTokens') as string) as UserTokens;
+            await AuthenticationService.refreshAccessToken(userTokens.refresh_token)
+                .then((response: AxiosResponse<string>) => {
+                    if (http2XX.test(response.status.toString())) {
+                        localStorage.setItem('UserTokens', JSON.stringify({
+                            ...userTokens,
+                            ...JSON.parse(response.data)
+                        }));
+                    }
+                });
+        }
     },
 
-    async getUserInfo({commit}: any) {
-        return await AuthenticationService.getUserInfo(state.userAccessToken)
-        .then((response: AxiosResponse<string>) => {
-            const jsonResponse: any = JSON.parse(response.data);
-            commit('userNameMutator', jsonResponse.sub.split(',')[0].substring(3));
-        });
+    async getUserInfo({commit, dispatch}: any) {
+        if (!localStorage.getItem('UserTokens')) {
+            dispatch('logOut');
+        } else {
+            const userTokens: UserTokens = JSON.parse(localStorage.getItem('UserTokens') as string) as UserTokens;
+            await AuthenticationService.getUserInfo(userTokens.access_token)
+                .then((response: AxiosResponse<string>) => {
+                    if (http2XX.test(response.status.toString())) {
+                        localStorage.setItem('UserInfo', response.data);
+                        const userInfo: UserInfo = JSON.parse(response.data) as UserInfo;
+                        const username: string = userInfo.sub.split(',')[0].split('=')[1];
+                        commit('usernameMutator', username);
+                    } else {
+                        dispatch('logOut');
+                    }
+                });
+        }
     },
 
     async logOut({commit}: any) {
-        return await AuthenticationService.revokeToken(state.userAccessToken)
-        .then((response: any) => {
-            AuthenticationService.revokeToken(state.userRefreshToken).then(()=>{
-                commit('loginMutator', true);
-                commit('userIdTokenMutator', '');
-                commit('userAccessTokenMutator', '');
-                commit('userRefreshTokenMutator', '');
-                commit('userNameMutator', '');
-            });
-        });
+        if (!localStorage.getItem('UserTokens')) {
+            commit('usernameMutator', '');
+            commit('authenticatedMutator', false);
+        } else {
+            localStorage.removeItem('UserInfo');
+            const userTokens: UserTokens = JSON.parse(localStorage.getItem('UserTokens') as string) as UserTokens;
+            localStorage.removeItem('UserTokens');
+            AuthenticationService.revokeToken(userTokens.access_token);
+            AuthenticationService.revokeToken(userTokens.refresh_token);
+            commit('usernameMutator', '');
+            commit('authenticatedMutator', false);
+        }
     }
 };
 


### PR DESCRIPTION
-updated authentication module with the localStorage functionality and reducing state to just an authenticated flag and username
-added an onLogout function that will redirect users to a landing page (need to flesh this out for production)
-added models for user tokens and user info
-updated authorization header to pull the bearer from local storage