### PR TITLE
Vnext/533 - Basic role-based authorization using ID tokens

### DIFF
--- a/BridgeCareApp/BridgeCare/BridgeCare.csproj
+++ b/BridgeCareApp/BridgeCare/BridgeCare.csproj
@@ -63,6 +63,15 @@
       <HintPath>..\packages\EPPlus.4.5.3.2\lib\net40\EPPlus.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.IdentityModel.JsonWebTokens, Version=5.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.JsonWebTokens.5.6.0\lib\net461\Microsoft.IdentityModel.JsonWebTokens.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Logging, Version=5.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Logging.5.6.0\lib\net461\Microsoft.IdentityModel.Logging.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Tokens, Version=5.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Tokens.5.6.0\lib\net461\Microsoft.IdentityModel.Tokens.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.SqlServer.ConnectionInfo, Version=14.100.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\iAM-legacy\Microsoft SQL Server assemblies\2012 (v11)\Microsoft.SqlServer.ConnectionInfo.dll</HintPath>
@@ -116,6 +125,9 @@
     </Reference>
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.IdentityModel.Tokens.Jwt, Version=5.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IdentityModel.Tokens.Jwt.5.6.0\lib\net461\System.IdentityModel.Tokens.Jwt.dll</HintPath>
+    </Reference>
     <Reference Include="System.Net.Http.Formatting, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.7\lib\net45\System.Net.Http.Formatting.dll</HintPath>
     </Reference>

--- a/BridgeCareApp/BridgeCare/Controllers/AuthenticationController.cs
+++ b/BridgeCareApp/BridgeCare/Controllers/AuthenticationController.cs
@@ -54,6 +54,11 @@ namespace BridgeCare.Controllers
             return responseTask.Result.Content.ReadAsStringAsync().Result;
         }
 
+        public static Dictionary<string,string> GetUserInfoDictionary(string token)
+        {
+            return DictionaryFromJSON(GetUserInfoString(token));
+        }
+
         /// <summary>
         /// API endpoint for fetching ID and Access tokens from ESEC using the OpenID Connect protocol
         /// </summary>

--- a/BridgeCareApp/BridgeCare/Controllers/AuthenticationController.cs
+++ b/BridgeCareApp/BridgeCare/Controllers/AuthenticationController.cs
@@ -41,19 +41,21 @@ namespace BridgeCare.Controllers
             var handler = new HttpClientHandler();
             handler.ServerCertificateCustomValidationCallback = (message, cert, chain, errors) => { return true; };
 
-            HttpClient client = new HttpClient(handler);
-            client.BaseAddress = new Uri(esecConfig["ESECBaseAddress"]);
-            client.DefaultRequestHeaders.Accept.Clear();
-            client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            using (HttpClient client = new HttpClient(handler))
+            {
+                client.BaseAddress = new Uri(esecConfig["ESECBaseAddress"]);
+                client.DefaultRequestHeaders.Accept.Clear();
+                client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
 
-            var formData = new List<KeyValuePair<string, string>>();
-            formData.Add(new KeyValuePair<string, string>("access_token", WebUtility.UrlDecode(token)));
-            HttpContent content = new FormUrlEncodedContent(formData);
+                var formData = new List<KeyValuePair<string, string>>();
+                formData.Add(new KeyValuePair<string, string>("access_token", WebUtility.UrlDecode(token)));
+                HttpContent content = new FormUrlEncodedContent(formData);
 
-            Task<HttpResponseMessage> responseTask = client.PostAsync("userinfo", content);
-            responseTask.Wait();
+                Task<HttpResponseMessage> responseTask = client.PostAsync("userinfo", content);
+                responseTask.Wait();
 
-            return responseTask.Result.Content.ReadAsStringAsync().Result;
+                return responseTask.Result.Content.ReadAsStringAsync().Result;
+            }
         }
 
         /// <summary>
@@ -80,27 +82,29 @@ namespace BridgeCare.Controllers
             var handler = new HttpClientHandler();
             handler.ServerCertificateCustomValidationCallback = (message, cert, chain, errors) => { return true; };
 
-            HttpClient client = new HttpClient(handler);
-            client.BaseAddress = new Uri(esecConfig["ESECBaseAddress"]);
-            client.DefaultRequestHeaders.Accept.Clear();
-            client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            using (HttpClient client = new HttpClient(handler))
+            {
+                client.BaseAddress = new Uri(esecConfig["ESECBaseAddress"]);
+                client.DefaultRequestHeaders.Accept.Clear();
+                client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
 
-            var formData = new List<KeyValuePair<string, string>>();
-            formData.Add(new KeyValuePair<string, string>("grant_type", "authorization_code"));
-            formData.Add(new KeyValuePair<string, string>("code", WebUtility.UrlDecode(code)));
-            formData.Add(new KeyValuePair<string, string>("redirect_uri", esecConfig["ESECRedirect"]));
-            formData.Add(new KeyValuePair<string, string>("client_id", esecConfig["ESECClientId"]));
-            formData.Add(new KeyValuePair<string, string>("client_secret", esecConfig["ESECClientSecret"]));
-            HttpContent content = new FormUrlEncodedContent(formData);
+                var formData = new List<KeyValuePair<string, string>>();
+                formData.Add(new KeyValuePair<string, string>("grant_type", "authorization_code"));
+                formData.Add(new KeyValuePair<string, string>("code", WebUtility.UrlDecode(code)));
+                formData.Add(new KeyValuePair<string, string>("redirect_uri", esecConfig["ESECRedirect"]));
+                formData.Add(new KeyValuePair<string, string>("client_id", esecConfig["ESECClientId"]));
+                formData.Add(new KeyValuePair<string, string>("client_secret", esecConfig["ESECClientSecret"]));
+                HttpContent content = new FormUrlEncodedContent(formData);
 
-            Task<HttpResponseMessage> responseTask = client.PostAsync("token", content);
-            responseTask.Wait();
+                Task<HttpResponseMessage> responseTask = client.PostAsync("token", content);
+                responseTask.Wait();
 
-            string response = responseTask.Result.Content.ReadAsStringAsync().Result;
+                string response = responseTask.Result.Content.ReadAsStringAsync().Result;
 
-            ValidateResponse(response);
+                ValidateResponse(response);
 
-            return Ok(response);
+                return Ok(response);
+            }
         }
 
         /// <summary>
@@ -117,26 +121,28 @@ namespace BridgeCare.Controllers
             var handler = new HttpClientHandler();
             handler.ServerCertificateCustomValidationCallback = (message, cert, chain, errors) => { return true; };
 
-            HttpClient client = new HttpClient(handler);
-            client.BaseAddress = new Uri(esecConfig["ESECBaseAddress"]);
-            client.DefaultRequestHeaders.Accept.Clear();
-            client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            using (HttpClient client = new HttpClient(handler))
+            {
+                client.BaseAddress = new Uri(esecConfig["ESECBaseAddress"]);
+                client.DefaultRequestHeaders.Accept.Clear();
+                client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
 
-            var formData = new List<KeyValuePair<string, string>>();
-            formData.Add(new KeyValuePair<string, string>("client_id", esecConfig["ESECClientId"]));
-            formData.Add(new KeyValuePair<string, string>("client_secret", esecConfig["ESECClientSecret"]));
-            HttpContent content = new FormUrlEncodedContent(formData);
+                var formData = new List<KeyValuePair<string, string>>();
+                formData.Add(new KeyValuePair<string, string>("client_id", esecConfig["ESECClientId"]));
+                formData.Add(new KeyValuePair<string, string>("client_secret", esecConfig["ESECClientSecret"]));
+                HttpContent content = new FormUrlEncodedContent(formData);
 
-            string query = $"?grant_type=refresh_token&refresh_token={WebUtility.UrlDecode(refreshToken)}";
+                string query = $"?grant_type=refresh_token&refresh_token={WebUtility.UrlDecode(refreshToken)}";
 
-            Task<HttpResponseMessage> responseTask = client.PostAsync("token" + query, content);
-            responseTask.Wait();
+                Task<HttpResponseMessage> responseTask = client.PostAsync("token" + query, content);
+                responseTask.Wait();
 
-            string response = responseTask.Result.Content.ReadAsStringAsync().Result;
+                string response = responseTask.Result.Content.ReadAsStringAsync().Result;
 
-            ValidateResponse(response);
+                ValidateResponse(response);
 
-            return Ok(response);
+                return Ok(response);
+            }
         }
 
         /// <summary>
@@ -153,29 +159,31 @@ namespace BridgeCare.Controllers
             var handler = new HttpClientHandler();
             handler.ServerCertificateCustomValidationCallback = (message, cert, chain, errors) => { return true; };
 
-            HttpClient client = new HttpClient(handler);
-            client.BaseAddress = new Uri(esecConfig["ESECBaseAddress"]);
-            client.DefaultRequestHeaders.Accept.Clear();
-            client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-
-            var formData = new List<KeyValuePair<string, string>>();
-            formData.Add(new KeyValuePair<string, string>("client_id", esecConfig["ESECClientId"]));
-            formData.Add(new KeyValuePair<string, string>("client_secret", esecConfig["ESECClientSecret"]));
-            HttpContent content = new FormUrlEncodedContent(formData);
-
-            string query = $"?token={WebUtility.UrlDecode(token)}";
-
-            Task<HttpResponseMessage> responseTask = client.PostAsync("revoke" + query, content);
-            responseTask.Wait();
-            if (responseTask.Result.StatusCode == HttpStatusCode.OK)
+            using (HttpClient client = new HttpClient(handler))
             {
-                return Ok();
+                client.BaseAddress = new Uri(esecConfig["ESECBaseAddress"]);
+                client.DefaultRequestHeaders.Accept.Clear();
+                client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+
+                var formData = new List<KeyValuePair<string, string>>();
+                formData.Add(new KeyValuePair<string, string>("client_id", esecConfig["ESECClientId"]));
+                formData.Add(new KeyValuePair<string, string>("client_secret", esecConfig["ESECClientSecret"]));
+                HttpContent content = new FormUrlEncodedContent(formData);
+
+                string query = $"?token={WebUtility.UrlDecode(token)}";
+
+                Task<HttpResponseMessage> responseTask = client.PostAsync("revoke" + query, content);
+                responseTask.Wait();
+                if (responseTask.Result.StatusCode == HttpStatusCode.OK)
+                {
+                    return Ok();
+                }
+
+                string response = responseTask.Result.Content.ReadAsStringAsync().Result;
+                ValidateResponse(response);
+
+                return Ok(response);
             }
-
-            string response = responseTask.Result.Content.ReadAsStringAsync().Result;
-            ValidateResponse(response);
-
-            return Ok(response);
         }
 
         /// <summary>

--- a/BridgeCareApp/BridgeCare/Controllers/AuthenticationController.cs
+++ b/BridgeCareApp/BridgeCare/Controllers/AuthenticationController.cs
@@ -1,15 +1,12 @@
 ﻿using System;
 using System.Configuration;
 using System.Security.Authentication;
-using System.Web;
 using System.Web.Http;
-using System.Web.Http.Cors;
 using System.Web.Script.Serialization;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
-using BridgeCare.Models;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 
@@ -32,6 +29,11 @@ namespace BridgeCare.Controllers
             return Ok(response);
         }
 
+        /// <summary>
+        /// Fetches user info as a JSON-formatted string from ESEC
+        /// </summary>
+        /// <param name="token">Access token</param>
+        /// <returns>JSON-formatted user info</returns>
         public static string GetUserInfoString(string token)
         {
             var esecConfig = (NameValueCollection)ConfigurationManager.GetSection("ESECConfig");
@@ -54,6 +56,11 @@ namespace BridgeCare.Controllers
             return responseTask.Result.Content.ReadAsStringAsync().Result;
         }
 
+        /// <summary>
+        /// Fetches user info as a dictionary
+        /// </summary>
+        /// <param name="token">Access token</param>
+        /// <returns>User info dictionary</returns>
         public static Dictionary<string,string> GetUserInfoDictionary(string token)
         {
             return DictionaryFromJSON(GetUserInfoString(token));

--- a/BridgeCareApp/BridgeCare/Controllers/CommittedProjectsController.cs
+++ b/BridgeCareApp/BridgeCare/Controllers/CommittedProjectsController.cs
@@ -27,7 +27,7 @@ namespace BridgeCare.Controllers
         /// <returns>IHttpActionResult</returns>
         [HttpPost]
         [Route("api/SaveCommittedProjectsFiles")]
-        [Filters.RestrictAccess]
+        [Filters.RestrictAccess("PD-BAMS-Administrator", "PD-BAMS-DBEngineer")]
         public IHttpActionResult SaveCommittedProjectsFiles()
         {
             if (!Request.Content.IsMimeMultipartContent())
@@ -46,7 +46,7 @@ namespace BridgeCare.Controllers
         [HttpPost]
         [Route("api/ExportCommittedProjects")]
         [ModelValidation("The scenario data is invalid.")]
-        [Filters.RestrictAccess]
+        [Filters.RestrictAccess("PD-BAMS-Administrator", "PD-BAMS-DBEngineer")]
         public HttpResponseMessage ExportCommittedProjects([FromBody]SimulationModel model)
         {
             var response = Request.CreateResponse();

--- a/BridgeCareApp/BridgeCare/Controllers/CriteriaDrivenBudgetsController.cs
+++ b/BridgeCareApp/BridgeCare/Controllers/CriteriaDrivenBudgetsController.cs
@@ -39,7 +39,7 @@ namespace BridgeCare.Controllers
         [HttpPost]
         [Route("api/SaveCriteriaDrivenBudgets/{id}")]
         [ModelValidation("The criteria driven budgets data is invalid.")]
-        [Filters.RestrictAccess]
+        [Filters.RestrictAccess("PD-BAMS-Administrator", "PD-BAMS-DBEngineer")]
         public IHttpActionResult SaveCriteriaDrivenBudgets(int id, [FromBody]List<CriteriaDrivenBudgetsModel> models)
         {
             var result = repo.SaveCriteriaDrivenBudgets(id, models, db);

--- a/BridgeCareApp/BridgeCare/Controllers/DeficientController.cs
+++ b/BridgeCareApp/BridgeCare/Controllers/DeficientController.cs
@@ -39,7 +39,7 @@ namespace BridgeCare.Controllers
         [HttpPost]
         [Route("api/SaveScenarioDeficientLibrary")]
         [ModelValidation("The deficient data is invalid.")]
-        [Filters.RestrictAccess]
+        [Filters.RestrictAccess("PD-BAMS-Administrator", "PD-BAMS-DBEngineer")]
         public IHttpActionResult SaveSimulationDeficientLibrary([FromBody] DeficientLibraryModel model)
             => Ok(repo.SaveSimulationDeficientLibrary(model, db));
     }

--- a/BridgeCareApp/BridgeCare/Controllers/Filters/RestrictAccessAttribute.cs
+++ b/BridgeCareApp/BridgeCare/Controllers/Filters/RestrictAccessAttribute.cs
@@ -14,6 +14,13 @@ namespace BridgeCare.Controllers.Filters
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
     public class RestrictAccessAttribute : AuthorizeAttribute
     {
+        private string[] PermittedRoles { get; set; }
+
+        public RestrictAccessAttribute (params string[] roles) : base()
+        {
+            this.PermittedRoles = roles;
+        }
+
         protected override bool IsAuthorized(HttpActionContext httpContext)
         {
             if (!httpContext.Request.Headers.Contains("Authorization"))
@@ -30,7 +37,19 @@ namespace BridgeCare.Controllers.Filters
             if (!userInfo.ContainsKey("roles")) {
                 return false;
             }
-            return true;
+            if (PermittedRoles.Length == 0)
+            {
+                return true;
+            }
+            string role = ParseRoleResponse(userInfo["roles"]);
+            return PermittedRoles.Contains(role);
+        }
+
+        private static string ParseRoleResponse(string roleResponse)
+        {
+            string firstSegment = roleResponse.Split(',')[0];
+            string role = firstSegment.Substring(3);
+            return role;
         }
     }
 }

--- a/BridgeCareApp/BridgeCare/Controllers/Filters/RestrictAccessAttribute.cs
+++ b/BridgeCareApp/BridgeCare/Controllers/Filters/RestrictAccessAttribute.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Web;
-using System.Web.Script.Serialization;
 using System.Web.Http;
 using System.Net.Http.Headers;
 using System.Web.Http.Controllers;

--- a/BridgeCareApp/BridgeCare/Controllers/InvestmentLibraryController.cs
+++ b/BridgeCareApp/BridgeCare/Controllers/InvestmentLibraryController.cs
@@ -41,7 +41,7 @@ namespace BridgeCare.Controllers
         [HttpPost]
         [Route("api/SaveScenarioInvestmentLibrary")]
         [ModelValidation("Given investment data is not valid")]
-        [Filters.RestrictAccess]
+        [Filters.RestrictAccess("PD-BAMS-Administrator", "PD-BAMS-DBEngineer")]
         public IHttpActionResult SaveSimulationInvestmentLibrary([FromBody]InvestmentLibraryModel model)
             => Ok(repo.SaveSimulationInvestmentLibrary(model, db));
     }

--- a/BridgeCareApp/BridgeCare/Controllers/PerformanceLibraryController.cs
+++ b/BridgeCareApp/BridgeCare/Controllers/PerformanceLibraryController.cs
@@ -37,7 +37,7 @@ namespace BridgeCare.Controllers
         [HttpPost]
         [Route("api/SaveScenarioPerformanceLibrary")]
         [ModelValidation("The performance data is invalid.")]
-        [Filters.RestrictAccess]
+        [Filters.RestrictAccess("PD-BAMS-Administrator", "PD-BAMS-DBEngineer")]
         public IHttpActionResult SaveSimulationPerformanceLibrary([FromBody]PerformanceLibraryModel model)
         {
             var performanceLibraryModel = repo.SaveSimulationPerformanceLibrary(model, db);

--- a/BridgeCareApp/BridgeCare/Controllers/PriorityController.cs
+++ b/BridgeCareApp/BridgeCare/Controllers/PriorityController.cs
@@ -27,7 +27,7 @@ namespace BridgeCare.Controllers
         [HttpGet]
         [Route("api/GetScenarioPriorityLibrary/{id}")]
         [ModelValidation("The scenario id is invalid.")]
-        [Filters.RestrictAccess("PD-BAMS-PlanningPartner")]
+        [Filters.RestrictAccess]
         public IHttpActionResult GetSimulationPriorityLibrary(int id) =>
             Ok(repo.GetSimulationPriorityLibrary(id, db));
 
@@ -39,7 +39,7 @@ namespace BridgeCare.Controllers
         [HttpPost]
         [Route("api/SaveScenarioPriorityLibrary")]
         [ModelValidation("The priority data is invalid.")]
-        [Filters.RestrictAccess("admin")]
+        [Filters.RestrictAccess("PD-BAMS-Administrator", "PD-BAMS-DBEngineer")]
         public IHttpActionResult SaveSimulationPriorityLibrary([FromBody]PriorityLibraryModel model) =>
             Ok(repo.SaveSimulationPriorityLibrary(model, db));
     }

--- a/BridgeCareApp/BridgeCare/Controllers/PriorityController.cs
+++ b/BridgeCareApp/BridgeCare/Controllers/PriorityController.cs
@@ -27,7 +27,7 @@ namespace BridgeCare.Controllers
         [HttpGet]
         [Route("api/GetScenarioPriorityLibrary/{id}")]
         [ModelValidation("The scenario id is invalid.")]
-        [Filters.RestrictAccess]
+        [Filters.RestrictAccess("PD-BAMS-PlanningPartner")]
         public IHttpActionResult GetSimulationPriorityLibrary(int id) =>
             Ok(repo.GetSimulationPriorityLibrary(id, db));
 
@@ -39,7 +39,7 @@ namespace BridgeCare.Controllers
         [HttpPost]
         [Route("api/SaveScenarioPriorityLibrary")]
         [ModelValidation("The priority data is invalid.")]
-        [Filters.RestrictAccess]
+        [Filters.RestrictAccess("admin")]
         public IHttpActionResult SaveSimulationPriorityLibrary([FromBody]PriorityLibraryModel model) =>
             Ok(repo.SaveSimulationPriorityLibrary(model, db));
     }

--- a/BridgeCareApp/BridgeCare/Controllers/RemainingLifeLimitController.cs
+++ b/BridgeCareApp/BridgeCare/Controllers/RemainingLifeLimitController.cs
@@ -36,7 +36,7 @@ namespace BridgeCare.Controllers
         /// <returns>IHttpActionResult</returns>
         [HttpPost]
         [Route("api/SaveScenarioRemainingLifeLimitLibrary")]
-        [Filters.RestrictAccess]
+        [Filters.RestrictAccess("PD-BAMS-Administrator", "PD-BAMS-DBEngineer")]
         public IHttpActionResult SaveSimulationRemainingLifeLimitLibrary([FromBody]RemainingLifeLimitLibraryModel model) =>
             Ok(repo.SaveSimulationRemainingLifeLimitLibrary(model, db));
     }

--- a/BridgeCareApp/BridgeCare/Controllers/SimulationAnalysisController.cs
+++ b/BridgeCareApp/BridgeCare/Controllers/SimulationAnalysisController.cs
@@ -34,7 +34,7 @@ namespace BridgeCare.Controllers
         /// <returns>IHttpActionResult</returns>
         [HttpPost]
         [Route("api/SaveScenarioAnalysisData")]
-        [Filters.RestrictAccess]
+        [Filters.RestrictAccess("PD-BAMS-Administrator", "PD-BAMS-DBEngineer")]
         public IHttpActionResult UpdateSimulationAnalysis([FromBody]SimulationAnalysisModel model)
         {
             repo.UpdateSimulationAnalysis(model, db);

--- a/BridgeCareApp/BridgeCare/Controllers/SimulationController.cs
+++ b/BridgeCareApp/BridgeCare/Controllers/SimulationController.cs
@@ -48,7 +48,7 @@ namespace BridgeCare.Controllers
         [HttpPost]
         [Route("api/UpdateScenario")]
         [ModelValidation("The scenario data is invalid.")]
-        [Filters.RestrictAccess]
+        [Filters.RestrictAccess("PD-BAMS-Administrator", "PD-BAMS-DBEngineer")]
         public IHttpActionResult UpdateSimulation([FromBody]SimulationModel model)
         {
             repo.UpdateSimulation(model, db);
@@ -63,7 +63,7 @@ namespace BridgeCare.Controllers
         [HttpDelete]
         [Route("api/DeleteScenario/{id}")]
         [ModelValidation("The scenario data is invalid.")]
-        [Filters.RestrictAccess]
+        [Filters.RestrictAccess("PD-BAMS-Administrator", "PD-BAMS-DBEngineer")]
         public IHttpActionResult DeleteSimulation(int id)
         {
             repo.DeleteSimulation(id, db);

--- a/BridgeCareApp/BridgeCare/Controllers/TargetController.cs
+++ b/BridgeCareApp/BridgeCare/Controllers/TargetController.cs
@@ -39,7 +39,7 @@ namespace BridgeCare.Controllers
         [HttpPost]
         [Route("api/SaveScenarioTargetLibrary")]
         [ModelValidation("The target data is invalid.")]
-        [Filters.RestrictAccess]
+        [Filters.RestrictAccess("PD-BAMS-Administrator", "PD-BAMS-DBEngineer")]
         public IHttpActionResult SaveSimulationTargetLibrary([FromBody]TargetLibraryModel model) => 
             Ok(repo.SaveSimulationTargetLibrary(model, db));
     }

--- a/BridgeCareApp/BridgeCare/Controllers/TreatmentLibraryController.cs
+++ b/BridgeCareApp/BridgeCare/Controllers/TreatmentLibraryController.cs
@@ -36,7 +36,7 @@ namespace BridgeCare.Controllers
         /// <returns>IHttpActionResult</returns>
         [HttpPost]
         [Route("api/SaveScenarioTreatmentLibrary")]
-        [Filters.RestrictAccess]
+        [Filters.RestrictAccess("PD-BAMS-Administrator", "PD-BAMS-DBEngineer")]
         public IHttpActionResult SaveSimulationTreatmentLibrary([FromBody]TreatmentLibraryModel model) =>
             Ok(repo.SaveSimulationTreatmentLibrary(model, db));
     }

--- a/BridgeCareApp/BridgeCare/Web.config
+++ b/BridgeCareApp/BridgeCare/Web.config
@@ -7,9 +7,9 @@
   <configSections>
     <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
     <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
-    <section name="ESECConfig" type="System.Configuration.NameValueFileSectionHandler, System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"/>
+    <section name="ESECConfig" type="System.Configuration.NameValueFileSectionHandler, System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   </configSections>
-  <ESECConfig configSource="esec.config"/>
+  <ESECConfig configSource="esec.config" />
   <connectionStrings configSource="connection.config">
   </connectionStrings>
   <appSettings>

--- a/BridgeCareApp/BridgeCare/packages.config
+++ b/BridgeCareApp/BridgeCare/packages.config
@@ -16,6 +16,9 @@
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.7" targetFramework="net471" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.4" targetFramework="net471" />
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="2.0.0" targetFramework="net471" />
+  <package id="Microsoft.IdentityModel.JsonWebTokens" version="5.6.0" targetFramework="net471" />
+  <package id="Microsoft.IdentityModel.Logging" version="5.6.0" targetFramework="net471" />
+  <package id="Microsoft.IdentityModel.Tokens" version="5.6.0" targetFramework="net471" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net471" />
   <package id="MongoDB.Bson" version="2.9.2" targetFramework="net471" />
   <package id="MongoDB.Driver" version="2.9.2" targetFramework="net471" />
@@ -26,6 +29,7 @@
   <package id="Snappy.NET" version="1.1.1.8" targetFramework="net471" />
   <package id="System.Buffers" version="4.4.0" targetFramework="net471" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.4.1" targetFramework="net471" />
+  <package id="System.IdentityModel.Tokens.Jwt" version="5.6.0" targetFramework="net471" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.2" targetFramework="net471" />
   <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net471" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net471" />

--- a/BridgeCareApp/BridgeCareNodeApp/app.js
+++ b/BridgeCareApp/BridgeCareNodeApp/app.js
@@ -3,6 +3,8 @@ const debug = require('debug')('app');
 const app = express();
 require('./config/express')(app);
 
+const passport = require("passport");
+
 const env = process.env.NODE_ENV = process.env.NODE_ENV || 'development';
 
 const config = require('./config/config')[env];

--- a/BridgeCareApp/BridgeCareNodeApp/authorization/authorizationConfig.js
+++ b/BridgeCareApp/BridgeCareNodeApp/authorization/authorizationConfig.js
@@ -1,0 +1,13 @@
+const authorizationConfig = {
+    esecPublicKey: {
+        "kty": "RSA",
+        "e": "AQAB",
+        "use": "sig",
+        "kid": "6b0dd418-def7-48cf-96d2-673bb0b0244f",
+        "n": "47FA3w2IWeIyh7IPr0NS7OeTpC94BtMLF8JMnqUWMLmWCud26lCb6-6L45BRoALPpksNwLfeRtf_jFE8kaoiiixJPP8jhL8oAVK9vE7X4KetUNT_HKtjzkp49Rvp0tpz-UKiv0F_u5XC54PdisfgQrstRMOHKUMeQEFjpF-pg9U"
+    },
+    issuer: 'https://oidcservicessyst.penndot.gov/affwebservices/CASSO/oidc/BAMS',
+    clientId: 'a56bb9d5-190d-4873-afea-0767d82dd91c'
+};
+
+module.exports = authorizationConfig;

--- a/BridgeCareApp/BridgeCareNodeApp/authorization/authorizationFilter.js
+++ b/BridgeCareApp/BridgeCareNodeApp/authorization/authorizationFilter.js
@@ -1,0 +1,34 @@
+const passport = require('passport');
+const jwkToPem = require('jwk-to-pem');
+const passportJwt = require('passport-jwt');
+const jwtStrategy = passportJwt.Strategy;
+const extractJwt = passportJwt.ExtractJwt;
+const authorizationConfig = require('./authorizationConfig');
+
+function authorizationFilter(permittedRoles) {
+    const jwtStrategyOptions = {
+        jwtFromRequest: extractJwt.fromAuthHeaderAsBearerToken(),
+        secretOrKey: jwkToPem(authorizationConfig.esecPublicKey),
+        issuer: authorizationConfig.issuer,
+        audience: authorizationConfig.clientId
+    };
+
+    function verify(jwtPayload, done) {
+        if (!Array.isArray(permittedRoles) || permittedRoles.length === 0) {
+            return done(null, jwtPayload);
+        }
+        console.log('verifying...');
+        console.log(jwtPayload.roles);
+        role = jwtPayload.roles.split(',')[0].split('=')[1];
+        if (permittedRoles.some(permittedRole => permittedRole === role)){
+            return done(null, jwtPayload);
+        }
+        return done(null, false);
+    };
+
+    const strategy = new jwtStrategy(jwtStrategyOptions, verify);
+    passport.use(strategy);
+    return passport.authenticate('jwt', { session: false });
+}
+
+module.exports = authorizationFilter;

--- a/BridgeCareApp/BridgeCareNodeApp/authorization/authorizationFilter.js
+++ b/BridgeCareApp/BridgeCareNodeApp/authorization/authorizationFilter.js
@@ -17,18 +17,19 @@ function authorizationFilter(permittedRoles) {
         if (!Array.isArray(permittedRoles) || permittedRoles.length === 0) {
             return done(null, jwtPayload);
         }
-        console.log('verifying...');
-        console.log(jwtPayload.roles);
         role = jwtPayload.roles.split(',')[0].split('=')[1];
         if (permittedRoles.some(permittedRole => permittedRole === role)){
             return done(null, jwtPayload);
         }
         return done(null, false);
-    };
+    }
 
     const strategy = new jwtStrategy(jwtStrategyOptions, verify);
-    passport.use(strategy);
-    return passport.authenticate('jwt', { session: false });
+
+    const strategyName = permittedRoles === undefined ? 'all' : permittedRoles.join(',');
+    
+    passport.use(strategyName, strategy);
+    return passport.authenticate(strategyName, { session: false });
 }
 
 module.exports = authorizationFilter;

--- a/BridgeCareApp/BridgeCareNodeApp/package.json
+++ b/BridgeCareApp/BridgeCareNodeApp/package.json
@@ -20,12 +20,15 @@
     "express": "^4.17.0",
     "http": "0.0.0",
     "install": "^0.12.2",
+    "jwk-to-pem": "^2.0.1",
     "mongodb": "3.2.6",
     "mongoose": "^5.5.11",
     "mongoose-sequence": "^5.0.1",
     "morgan": "^1.9.1",
     "nodemon": "^1.19.0",
     "npm": "^6.9.0",
+    "passport": "^0.4.0",
+    "passport-jwt": "^4.0.0",
     "socket.io": "^2.2.0"
   },
   "devDependencies": {

--- a/BridgeCareApp/BridgeCareNodeApp/routers/deficientLibraryRouter.js
+++ b/BridgeCareApp/BridgeCareNodeApp/routers/deficientLibraryRouter.js
@@ -1,13 +1,14 @@
 const express = require('express');
 const deficientLibraryController = require('../controllers/deficientLibraryController');
+const authorizationFilter = require('../authorization/authorizationFilter');
 
 function deficientLibraryRouter(DeficientLibrary) {
     const router = express.Router();
     const controller = deficientLibraryController(DeficientLibrary);
 
-    router.route('/GetDeficientLibraries').get(controller.get);
-    router.route('/CreateDeficientLibrary').post(controller.post);
-    router.route('/UpdateDeficientLibrary').put(controller.put);
+    router.route('/GetDeficientLibraries').get(authorizationFilter(), controller.get);
+    router.route('/CreateDeficientLibrary').post(authorizationFilter(), controller.post);
+    router.route('/UpdateDeficientLibrary').put(authorizationFilter(), controller.put);
 
     return router;
 }

--- a/BridgeCareApp/BridgeCareNodeApp/routers/deficientLibraryRouter.js
+++ b/BridgeCareApp/BridgeCareNodeApp/routers/deficientLibraryRouter.js
@@ -7,8 +7,8 @@ function deficientLibraryRouter(DeficientLibrary) {
     const controller = deficientLibraryController(DeficientLibrary);
 
     router.route('/GetDeficientLibraries').get(authorizationFilter(), controller.get);
-    router.route('/CreateDeficientLibrary').post(authorizationFilter(), controller.post);
-    router.route('/UpdateDeficientLibrary').put(authorizationFilter(), controller.put);
+    router.route('/CreateDeficientLibrary').post(authorizationFilter(["PD-BAMS-Administrator", "PD-BAMS-DBEngineer"]), controller.post);
+    router.route('/UpdateDeficientLibrary').put(authorizationFilter(["PD-BAMS-Administrator", "PD-BAMS-DBEngineer"]), controller.put);
 
     return router;
 }

--- a/BridgeCareApp/BridgeCareNodeApp/routers/investmentLibraryRouter.js
+++ b/BridgeCareApp/BridgeCareNodeApp/routers/investmentLibraryRouter.js
@@ -1,15 +1,16 @@
 const express = require('express');
 const investmentLibraryController = require('../controllers/investmentLibraryController');
+const authorizationFilter = require('../authorization/authorizationFilter');
 
 function investmentLibraryRouter(InvestmentLibrary){
     const router = express.Router();
     const controller = investmentLibraryController(InvestmentLibrary);
 
-    router.route("/GetInvestmentLibraries").get(controller.get);
-    router.route("/CreateInvestmentLibrary").post(controller.post);
-    router.route("/UpdateInvestmentLibrary").put(controller.put);
-    router.route("/GetInvestmentLibrary/:investmentLibraryId").get(controller.getById);
-    router.route("/DeleteInvestmentLibrary/:investmentLibraryId").delete(controller.deleteLibrary);
+    router.route("/GetInvestmentLibraries").get(authorizationFilter(), controller.get);
+    router.route("/CreateInvestmentLibrary").post(authorizationFilter(), controller.post);
+    router.route("/UpdateInvestmentLibrary").put(authorizationFilter(), controller.put);
+    router.route("/GetInvestmentLibrary/:investmentLibraryId").get(authorizationFilter(), controller.getById);
+    router.route("/DeleteInvestmentLibrary/:investmentLibraryId").delete(authorizationFilter(), controller.deleteLibrary);
 
     return router;
 }

--- a/BridgeCareApp/BridgeCareNodeApp/routers/investmentLibraryRouter.js
+++ b/BridgeCareApp/BridgeCareNodeApp/routers/investmentLibraryRouter.js
@@ -7,10 +7,10 @@ function investmentLibraryRouter(InvestmentLibrary){
     const controller = investmentLibraryController(InvestmentLibrary);
 
     router.route("/GetInvestmentLibraries").get(authorizationFilter(), controller.get);
-    router.route("/CreateInvestmentLibrary").post(authorizationFilter(), controller.post);
-    router.route("/UpdateInvestmentLibrary").put(authorizationFilter(), controller.put);
+    router.route("/CreateInvestmentLibrary").post(authorizationFilter(["PD-BAMS-Administrator", "PD-BAMS-DBEngineer"]), controller.post);
+    router.route("/UpdateInvestmentLibrary").put(authorizationFilter(["PD-BAMS-Administrator", "PD-BAMS-DBEngineer"]), controller.put);
     router.route("/GetInvestmentLibrary/:investmentLibraryId").get(authorizationFilter(), controller.getById);
-    router.route("/DeleteInvestmentLibrary/:investmentLibraryId").delete(authorizationFilter(), controller.deleteLibrary);
+    router.route("/DeleteInvestmentLibrary/:investmentLibraryId").delete(authorizationFilter(["PD-BAMS-Administrator", "PD-BAMS-DBEngineer"]), controller.deleteLibrary);
 
     return router;
 }

--- a/BridgeCareApp/BridgeCareNodeApp/routers/networkRouter.js
+++ b/BridgeCareApp/BridgeCareNodeApp/routers/networkRouter.js
@@ -1,15 +1,16 @@
 const express = require('express');
 const networkController = require('../controllers/networkController');
+const authorizationFilter = require('../authorization/authorizationFilter');
 
 function networkRouter(Network){
     const router = express.Router();
     const controller = networkController(Network);
 
     router.route("/GetMongoRollups")
-        .post(controller.post)
-        .get(controller.get);
-    router.route("/UpdateMongoRollup/:networkId").put(controller.put);
-    router.route("/AddLegacyNetworks").post(controller.postLegacyNetworks);
+        .post(authorizationFilter(), controller.post)
+        .get(authorizationFilter(), controller.get);
+    router.route("/UpdateMongoRollup/:networkId").put(authorizationFilter(), controller.put);
+    router.route("/AddLegacyNetworks").post(authorizationFilter(), controller.postLegacyNetworks);
 
     return router;
 }

--- a/BridgeCareApp/BridgeCareNodeApp/routers/performanceLibraryRouter.js
+++ b/BridgeCareApp/BridgeCareNodeApp/routers/performanceLibraryRouter.js
@@ -1,14 +1,15 @@
 const express = require('express');
 const performanceLibraryController = require('../controllers/performanceLibraryController');
+const authorizationFilter = require('../authorization/authorizationFilter');
 
 function performanceLibraryRouter(PerformanceLibrary, connectionTest) {
     const router = express.Router();
     const controller = performanceLibraryController(PerformanceLibrary);
 
-    router.route('/GetPerformanceLibraries').get(controller.get);
-    router.route('/CreatePerformanceLibrary').post(controller.post);
-    router.route('/UpdatePerformanceLibrary').put(controller.put);
-    router.route('/DeletePerformanceLibrary/:performanceLibraryId').delete(controller.deleteLibrary);
+    router.route('/GetPerformanceLibraries').get(authorizationFilter(), controller.get);
+    router.route('/CreatePerformanceLibrary').post(authorizationFilter(), controller.post);
+    router.route('/UpdatePerformanceLibrary').put(authorizationFilter(), controller.put);
+    router.route('/DeletePerformanceLibrary/:performanceLibraryId').delete(authorizationFilter(), controller.deleteLibrary);
     router.route('/').get((req, res) => {
         return res.send(connectionTest);
     });

--- a/BridgeCareApp/BridgeCareNodeApp/routers/performanceLibraryRouter.js
+++ b/BridgeCareApp/BridgeCareNodeApp/routers/performanceLibraryRouter.js
@@ -7,9 +7,9 @@ function performanceLibraryRouter(PerformanceLibrary, connectionTest) {
     const controller = performanceLibraryController(PerformanceLibrary);
 
     router.route('/GetPerformanceLibraries').get(authorizationFilter(), controller.get);
-    router.route('/CreatePerformanceLibrary').post(authorizationFilter(), controller.post);
-    router.route('/UpdatePerformanceLibrary').put(authorizationFilter(), controller.put);
-    router.route('/DeletePerformanceLibrary/:performanceLibraryId').delete(authorizationFilter(), controller.deleteLibrary);
+    router.route('/CreatePerformanceLibrary').post(authorizationFilter(["PD-BAMS-Administrator", "PD-BAMS-DBEngineer"]), controller.post);
+    router.route('/UpdatePerformanceLibrary').put(authorizationFilter(["PD-BAMS-Administrator", "PD-BAMS-DBEngineer"]), controller.put);
+    router.route('/DeletePerformanceLibrary/:performanceLibraryId').delete(authorizationFilter(["PD-BAMS-Administrator", "PD-BAMS-DBEngineer"]), controller.deleteLibrary);
     router.route('/').get((req, res) => {
         return res.send(connectionTest);
     });

--- a/BridgeCareApp/BridgeCareNodeApp/routers/priorityLibraryRouter.js
+++ b/BridgeCareApp/BridgeCareNodeApp/routers/priorityLibraryRouter.js
@@ -1,13 +1,14 @@
 const express = require('express');
 const priorityLibraryController = require('../controllers/priorityLibraryController');
+const authorizationFilter = require('../authorization/authorizationFilter');
 
 function priorityLibraryRouter(PriorityLibrary) {
     const router = express.Router();
     const controller = priorityLibraryController(PriorityLibrary);
 
-    router.route('/GetPriorityLibraries').get(controller.get);
-    router.route('/CreatePriorityLibrary').post(controller.post);
-    router.route('/UpdatePriorityLibrary').put(controller.put);
+    router.route('/GetPriorityLibraries').get(authorizationFilter(), controller.get);
+    router.route('/CreatePriorityLibrary').post(authorizationFilter(), controller.post);
+    router.route('/UpdatePriorityLibrary').put(authorizationFilter(), controller.put);
 
     return router;
 }

--- a/BridgeCareApp/BridgeCareNodeApp/routers/priorityLibraryRouter.js
+++ b/BridgeCareApp/BridgeCareNodeApp/routers/priorityLibraryRouter.js
@@ -7,8 +7,8 @@ function priorityLibraryRouter(PriorityLibrary) {
     const controller = priorityLibraryController(PriorityLibrary);
 
     router.route('/GetPriorityLibraries').get(authorizationFilter(), controller.get);
-    router.route('/CreatePriorityLibrary').post(authorizationFilter(), controller.post);
-    router.route('/UpdatePriorityLibrary').put(authorizationFilter(), controller.put);
+    router.route('/CreatePriorityLibrary').post(authorizationFilter(["PD-BAMS-Administrator", "PD-BAMS-DBEngineer"]), controller.post);
+    router.route('/UpdatePriorityLibrary').put(authorizationFilter(["PD-BAMS-Administrator", "PD-BAMS-DBEngineer"]), controller.put);
 
     return router;
 }

--- a/BridgeCareApp/BridgeCareNodeApp/routers/remainingLifeLimitLibraryRouter.js
+++ b/BridgeCareApp/BridgeCareNodeApp/routers/remainingLifeLimitLibraryRouter.js
@@ -6,9 +6,9 @@ function remainingLifeLimitLibraryRouter(RemainingLifeLimitLibrary) {
     const router = express.Router();
     const controller = remainingLifeLimitLibraryController(RemainingLifeLimitLibrary);
 
-    router.route('/GetRemainingLifeLimitLibraries').get(authorizationFilter(), controller.get);
-    router.route('/CreateRemainingLifeLimitLibrary').post(authorizationFilter(), controller.post);
-    router.route('/UpdateRemainingLifeLimitLibrary').put(authorizationFilter(), controller.put);
+    router.route('/GetRemainingLifeLimitLibraries').get(authorizationFilter(["PD-BAMS-Administrator"]), controller.get);
+    router.route('/CreateRemainingLifeLimitLibrary').post(authorizationFilter(["PD-BAMS-Administrator"]), controller.post);
+    router.route('/UpdateRemainingLifeLimitLibrary').put(authorizationFilter(["PD-BAMS-Administrator"]), controller.put);
 
     return router;
 }

--- a/BridgeCareApp/BridgeCareNodeApp/routers/remainingLifeLimitLibraryRouter.js
+++ b/BridgeCareApp/BridgeCareNodeApp/routers/remainingLifeLimitLibraryRouter.js
@@ -1,13 +1,14 @@
 const express = require('express');
 const remainingLifeLimitLibraryController = require('../controllers/remainingLifeLimitLibraryController');
+const authorizationFilter = require('../authorization/authorizationFilter');
 
 function remainingLifeLimitLibraryRouter(RemainingLifeLimitLibrary) {
     const router = express.Router();
     const controller = remainingLifeLimitLibraryController(RemainingLifeLimitLibrary);
 
-    router.route('/GetRemainingLifeLimitLibraries').get(controller.get);
-    router.route('/CreateRemainingLifeLimitLibrary').post(controller.post);
-    router.route('/UpdateRemainingLifeLimitLibrary').put(controller.put);
+    router.route('/GetRemainingLifeLimitLibraries').get(authorizationFilter(), controller.get);
+    router.route('/CreateRemainingLifeLimitLibrary').post(authorizationFilter(), controller.post);
+    router.route('/UpdateRemainingLifeLimitLibrary').put(authorizationFilter(), controller.put);
 
     return router;
 }

--- a/BridgeCareApp/BridgeCareNodeApp/routers/scenarioRouter.js
+++ b/BridgeCareApp/BridgeCareNodeApp/routers/scenarioRouter.js
@@ -9,8 +9,8 @@ function scenarioRoutes(Scenario){
     router.route("/GetMongoScenarios")
         .post(authorizationFilter(), controller.post)
         .get(authorizationFilter(), controller.get);
-    router.route("/DeleteMongoScenario/:scenarioId").delete(authorizationFilter(), controller.deleteScenario);
-    router.route("/UpdateMongoScenario/:scenarioId").put(authorizationFilter(), controller.put);
+    router.route("/DeleteMongoScenario/:scenarioId").delete(authorizationFilter(["PD-BAMS-Administrator", "PD-BAMS-DBEngineer"]), controller.deleteScenario);
+    router.route("/UpdateMongoScenario/:scenarioId").put(authorizationFilter(["PD-BAMS-Administrator", "PD-BAMS-DBEngineer"]), controller.put);
     router.route("/AddMultipleScenarios").post(authorizationFilter(), controller.postMultipleScenarios);
 
     return router;

--- a/BridgeCareApp/BridgeCareNodeApp/routers/scenarioRouter.js
+++ b/BridgeCareApp/BridgeCareNodeApp/routers/scenarioRouter.js
@@ -1,16 +1,17 @@
 const express = require('express');
 const scenarioController = require('../controllers/scenarioController');
+const authorizationFilter = require('../authorization/authorizationFilter');
 
 function scenarioRoutes(Scenario){
     const router = express.Router();
     const controller = scenarioController(Scenario);
 
     router.route("/GetMongoScenarios")
-        .post(controller.post)
-        .get(controller.get);
-    router.route("/DeleteMongoScenario/:scenarioId").delete(controller.deleteScenario);
-    router.route("/UpdateMongoScenario/:scenarioId").put(controller.put);
-    router.route("/AddMultipleScenarios").post(controller.postMultipleScenarios);
+        .post(authorizationFilter(), controller.post)
+        .get(authorizationFilter(), controller.get);
+    router.route("/DeleteMongoScenario/:scenarioId").delete(authorizationFilter(), controller.deleteScenario);
+    router.route("/UpdateMongoScenario/:scenarioId").put(authorizationFilter(), controller.put);
+    router.route("/AddMultipleScenarios").post(authorizationFilter(), controller.postMultipleScenarios);
 
     return router;
 }

--- a/BridgeCareApp/BridgeCareNodeApp/routers/targetLibraryRouter.js
+++ b/BridgeCareApp/BridgeCareNodeApp/routers/targetLibraryRouter.js
@@ -7,8 +7,8 @@ function targetLibraryRouter(TargetLibrary) {
     const controller = targetLibraryController(TargetLibrary);
 
     router.route('/GetTargetLibraries').get(authorizationFilter(), controller.get);
-    router.route('/CreateTargetLibrary').post(authorizationFilter(), controller.post);
-    router.route('/UpdateTargetLibrary').put(authorizationFilter(), controller.put);
+    router.route('/CreateTargetLibrary').post(authorizationFilter(["PD-BAMS-Administrator", "PD-BAMS-DBEngineer"]), controller.post);
+    router.route('/UpdateTargetLibrary').put(authorizationFilter(["PD-BAMS-Administrator", "PD-BAMS-DBEngineer"]), controller.put);
 
     return router;
 }

--- a/BridgeCareApp/BridgeCareNodeApp/routers/targetLibraryRouter.js
+++ b/BridgeCareApp/BridgeCareNodeApp/routers/targetLibraryRouter.js
@@ -1,13 +1,14 @@
 const express = require('express');
 const targetLibraryController = require('../controllers/targetLibraryController');
+const authorizationFilter = require('../authorization/authorizationFilter');
 
 function targetLibraryRouter(TargetLibrary) {
     const router = express.Router();
     const controller = targetLibraryController(TargetLibrary);
 
-    router.route('/GetTargetLibraries').get(controller.get);
-    router.route('/CreateTargetLibrary').post(controller.post);
-    router.route('/UpdateTargetLibrary').put(controller.put);
+    router.route('/GetTargetLibraries').get(authorizationFilter(), controller.get);
+    router.route('/CreateTargetLibrary').post(authorizationFilter(), controller.post);
+    router.route('/UpdateTargetLibrary').put(authorizationFilter(), controller.put);
 
     return router;
 }

--- a/BridgeCareApp/BridgeCareNodeApp/routers/treatmentLibraryRouter.js
+++ b/BridgeCareApp/BridgeCareNodeApp/routers/treatmentLibraryRouter.js
@@ -7,9 +7,9 @@ function treatmentLibraryRouter(TreatmentLibrary, connectionTest) {
     const controller = treatmentLibraryController(TreatmentLibrary);
 
     router.route('/GetTreatmentLibraries').get(authorizationFilter(), controller.get);
-    router.route('/CreateTreatmentLibrary').post(authorizationFilter(), controller.post);
-    router.route('/UpdateTreatmentLibrary').put(authorizationFilter(), controller.put);
-    router.route('/DeleteTreatmentLibrary/:treatmentLibraryId').delete(authorizationFilter(), controller.deleteLibrary);
+    router.route('/CreateTreatmentLibrary').post(authorizationFilter(["PD-BAMS-Administrator", "PD-BAMS-DBEngineer"]), controller.post);
+    router.route('/UpdateTreatmentLibrary').put(authorizationFilter(["PD-BAMS-Administrator", "PD-BAMS-DBEngineer"]), controller.put);
+    router.route('/DeleteTreatmentLibrary/:treatmentLibraryId').delete(authorizationFilter(["PD-BAMS-Administrator", "PD-BAMS-DBEngineer"]), controller.deleteLibrary);
     router.route('/').get((req, res) => {
         return res.send(connectionTest);
     });

--- a/BridgeCareApp/BridgeCareNodeApp/routers/treatmentLibraryRouter.js
+++ b/BridgeCareApp/BridgeCareNodeApp/routers/treatmentLibraryRouter.js
@@ -1,14 +1,15 @@
 const express = require('express');
 const treatmentLibraryController = require('../controllers/treatmentLibraryController');
+const authorizationFilter = require('../authorization/authorizationFilter');
 
 function treatmentLibraryRouter(TreatmentLibrary, connectionTest) {
     const router = express.Router();
     const controller = treatmentLibraryController(TreatmentLibrary);
 
-    router.route('/GetTreatmentLibraries').get(controller.get);
-    router.route('/CreateTreatmentLibrary').post(controller.post);
-    router.route('/UpdateTreatmentLibrary').put(controller.put);
-    router.route('/DeleteTreatmentLibrary/:treatmentLibraryId').delete(controller.deleteLibrary);
+    router.route('/GetTreatmentLibraries').get(authorizationFilter(), controller.get);
+    router.route('/CreateTreatmentLibrary').post(authorizationFilter(), controller.post);
+    router.route('/UpdateTreatmentLibrary').put(authorizationFilter(), controller.put);
+    router.route('/DeleteTreatmentLibrary/:treatmentLibraryId').delete(authorizationFilter(), controller.deleteLibrary);
     router.route('/').get((req, res) => {
         return res.send(connectionTest);
     });

--- a/BridgeCareApp/VuejsApp/src/App.vue
+++ b/BridgeCareApp/VuejsApp/src/App.vue
@@ -215,7 +215,7 @@
                 } else {
                     this.onLogout();
                 }
-            }, 120000);
+            }, 29 * 60 * 1000); // 29 minutes between token refreshes
         }
 
         /**

--- a/BridgeCareApp/VuejsApp/src/App.vue
+++ b/BridgeCareApp/VuejsApp/src/App.vue
@@ -207,15 +207,15 @@
                 (error: any) => errorHandler(error)
             );
 
-            // Every two minutes, the access token will be refreshed if a user is logged in.
-            // Since tokens last 5 minutes, one failed refresh attempt will not disrupt authentication.
+            // Every 29 minutes, the access token will be refreshed if a user is logged in.
+            // Tokens last 30 minutes
             window.setInterval(() => {
                 if (this.authenticated) {
                     this.refreshAccessTokenAction();
                 } else {
                     this.onLogout();
                 }
-            }, 29 * 60 * 1000); // 29 minutes between token refreshes
+            }, 29 * 60 * 1000);
         }
 
         /**

--- a/BridgeCareApp/VuejsApp/src/App.vue
+++ b/BridgeCareApp/VuejsApp/src/App.vue
@@ -106,7 +106,7 @@
         @State(state => state.toastr.infoMessage) infoMessage: string;
         @State(state => state.scenario.selectedScenarioName) stateSelectedScenarioName: string;
 
-        @Action('refreshAccessToken') refreshAccessTokenAction: any;
+        @Action('refreshTokens') refreshTokensAction: any;
         @Action('logOut') logOutAction: any;
         @Action('setIsBusy') setIsBusyAction: any;
         @Action('getNetworks') getNetworksAction: any;
@@ -207,11 +207,11 @@
                 (error: any) => errorHandler(error)
             );
 
-            // Every 29 minutes, the access token will be refreshed if a user is logged in.
+            // Every 29 minutes, all tokens will be refreshed if a user is logged in.
             // Tokens last 30 minutes
             window.setInterval(() => {
                 if (this.authenticated) {
-                    this.refreshAccessTokenAction();
+                    this.refreshTokensAction();
                 } else {
                     this.onLogout();
                 }

--- a/BridgeCareApp/VuejsApp/src/services/authentication.service.ts
+++ b/BridgeCareApp/VuejsApp/src/services/authentication.service.ts
@@ -18,7 +18,7 @@ export default class AuthenticationService {
         });
     }
 
-    static refreshAccessToken(refreshToken: string): AxiosPromise {
+    static refreshTokens(refreshToken: string): AxiosPromise {
         return new Promise<AxiosResponse> ((resolve) => {
             axiosInstance.get(`/authentication/RefreshToken/${refreshToken}`)
             .then((response: AxiosResponse<string>) => {

--- a/BridgeCareApp/VuejsApp/src/services/deficient.service.ts
+++ b/BridgeCareApp/VuejsApp/src/services/deficient.service.ts
@@ -25,7 +25,7 @@ export default class DeficientService {
      * Gets deficient libraries
      */
     static getDeficientLibraries(): AxiosPromise {
-        return nodejsAxiosInstance.get('/api/GetDeficientLibraries');
+        return nodejsAxiosInstance.get('/api/GetDeficientLibraries', {headers: getAuthorizationHeader()});
     }
 
     /**
@@ -33,7 +33,7 @@ export default class DeficientService {
      * @param createdDeficientLibrary The deficient library create data
      */
     static createDeficientLibrary(createdDeficientLibrary: DeficientLibrary): AxiosPromise {
-        return nodejsAxiosInstance.post('/api/CreateDeficientLibrary', modifyDataForMongoDB(createdDeficientLibrary));
+        return nodejsAxiosInstance.post('/api/CreateDeficientLibrary', modifyDataForMongoDB(createdDeficientLibrary), {headers: getAuthorizationHeader()});
     }
 
     /**
@@ -41,7 +41,7 @@ export default class DeficientService {
      * @param updatedDeficientLibrary The deficient library update data
      */
     static updateDeficientLibrary(updatedDeficientLibrary: DeficientLibrary): AxiosPromise {
-        return nodejsAxiosInstance.put('/api/UpdateDeficientLibrary', modifyDataForMongoDB(updatedDeficientLibrary));
+        return nodejsAxiosInstance.put('/api/UpdateDeficientLibrary', modifyDataForMongoDB(updatedDeficientLibrary), {headers: getAuthorizationHeader()});
     }
 
     /**

--- a/BridgeCareApp/VuejsApp/src/services/investment-editor.service.ts
+++ b/BridgeCareApp/VuejsApp/src/services/investment-editor.service.ts
@@ -27,7 +27,7 @@ export default class InvestmentEditorService {
      * Gets all investment libraries
      */
     static getInvestmentLibraries(): AxiosPromise {
-        return nodejsAxiosInstance.get('/api/GetInvestmentLibraries');
+        return nodejsAxiosInstance.get('/api/GetInvestmentLibraries', {headers: getAuthorizationHeader()});
     }
 
     /**
@@ -35,7 +35,7 @@ export default class InvestmentEditorService {
      * @param createdInvestmentLibrary The investment library create data
      */
     static createInvestmentLibrary(createdInvestmentLibrary: InvestmentLibrary): AxiosPromise {
-        return nodejsAxiosInstance.post('/api/CreateInvestmentLibrary', modifyDataForMongoDB(createdInvestmentLibrary));
+        return nodejsAxiosInstance.post('/api/CreateInvestmentLibrary', modifyDataForMongoDB(createdInvestmentLibrary), {headers: getAuthorizationHeader()});
     }
 
     /**
@@ -43,7 +43,7 @@ export default class InvestmentEditorService {
      * @param updatedInvestmentLibrary The investment library update data
      */
     static updateInvestmentLibrary(updatedInvestmentLibrary: InvestmentLibrary): AxiosPromise {
-        return nodejsAxiosInstance.put('/api/UpdateInvestmentLibrary', modifyDataForMongoDB(updatedInvestmentLibrary));
+        return nodejsAxiosInstance.put('/api/UpdateInvestmentLibrary', modifyDataForMongoDB(updatedInvestmentLibrary), {headers: getAuthorizationHeader()});
     }
 
     /**

--- a/BridgeCareApp/VuejsApp/src/services/performance-editor.service.ts
+++ b/BridgeCareApp/VuejsApp/src/services/performance-editor.service.ts
@@ -22,7 +22,7 @@ export default class PerformanceEditorService {
      * Gets all performance Libraries a user can read/edit
      */
     static getPerformanceLibraries(): AxiosPromise {
-        return nodejsAxiosInstance.get('/api/GetPerformanceLibraries');
+        return nodejsAxiosInstance.get('/api/GetPerformanceLibraries', {headers: getAuthorizationHeader()});
     }
 
     /**
@@ -30,7 +30,7 @@ export default class PerformanceEditorService {
      * @param createPerformanceLibraryData The performance library create data
      */
     static createPerformanceLibrary(createPerformanceLibraryData: PerformanceLibrary): AxiosPromise {
-        return nodejsAxiosInstance.post('/api/CreatePerformanceLibrary', modifyDataForMongoDB(createPerformanceLibraryData));
+        return nodejsAxiosInstance.post('/api/CreatePerformanceLibrary', modifyDataForMongoDB(createPerformanceLibraryData), {headers: getAuthorizationHeader()});
     }
 
     /**
@@ -38,7 +38,7 @@ export default class PerformanceEditorService {
      * @param updatePerformanceLibraryData The performance library update data
      */
     static updatePerformanceLibrary(updatePerformanceLibraryData: PerformanceLibrary): AxiosPromise {
-        return nodejsAxiosInstance.put('/api/UpdatePerformanceLibrary', modifyDataForMongoDB(updatePerformanceLibraryData));
+        return nodejsAxiosInstance.put('/api/UpdatePerformanceLibrary', modifyDataForMongoDB(updatePerformanceLibraryData), {headers: getAuthorizationHeader()});
     }
 
     /**

--- a/BridgeCareApp/VuejsApp/src/services/priority.service.ts
+++ b/BridgeCareApp/VuejsApp/src/services/priority.service.ts
@@ -33,7 +33,7 @@ export default class PriorityService {
      * Gets priority libraries data
      */
     static getPriorityLibraries(): AxiosPromise {
-        return nodejsAxiosInstance.get('/api/GetPriorityLibraries');
+        return nodejsAxiosInstance.get('/api/GetPriorityLibraries', {headers: getAuthorizationHeader()});
     }
 
     /**
@@ -41,7 +41,7 @@ export default class PriorityService {
      * @param createdPriorityLibrary The priority library create data
      */
     static createPriorityLibrary(createdPriorityLibrary: PriorityLibrary): AxiosPromise {
-        return nodejsAxiosInstance.post('/api/CreatePriorityLibrary', modifyDataForMongoDB(createdPriorityLibrary));
+        return nodejsAxiosInstance.post('/api/CreatePriorityLibrary', modifyDataForMongoDB(createdPriorityLibrary), {headers: getAuthorizationHeader()});
     }
 
     /**
@@ -49,7 +49,7 @@ export default class PriorityService {
      * @param updatedPriorityLibrary The priority library update data
      */
     static updatePriorityLibrary(updatedPriorityLibrary: PriorityLibrary): AxiosPromise {
-        return nodejsAxiosInstance.put('/api/UpdatePriorityLibrary', modifyDataForMongoDB(updatedPriorityLibrary));
+        return nodejsAxiosInstance.put('/api/UpdatePriorityLibrary', modifyDataForMongoDB(updatedPriorityLibrary), {headers: getAuthorizationHeader()});
     }
 
     /**

--- a/BridgeCareApp/VuejsApp/src/services/remaining-life-limit.service.ts
+++ b/BridgeCareApp/VuejsApp/src/services/remaining-life-limit.service.ts
@@ -23,7 +23,7 @@ export default class RemainingLifeLimitService {
      * Gets all remaining life limit libraries
      */
     static getRemainingLifeLimitLibraries(): AxiosPromise {
-        return nodejsAxiosInstance.get('/api/GetRemainingLifeLimitLibraries');
+        return nodejsAxiosInstance.get('/api/GetRemainingLifeLimitLibraries', {headers: getAuthorizationHeader()});
     }
 
     /**
@@ -31,7 +31,7 @@ export default class RemainingLifeLimitService {
      * @param createdRemainingLifeLimitLibrary The remaining life limit library create data
      */
     static createRemainingLifeLimitLibrary(createdRemainingLifeLimitLibrary: RemainingLifeLimitLibrary): AxiosPromise {
-        return nodejsAxiosInstance.post('/api/CreateRemainingLifeLimitLibrary', modifyDataForMongoDB(createdRemainingLifeLimitLibrary));
+        return nodejsAxiosInstance.post('/api/CreateRemainingLifeLimitLibrary', modifyDataForMongoDB(createdRemainingLifeLimitLibrary), {headers: getAuthorizationHeader()});
     }
 
     /**
@@ -39,7 +39,7 @@ export default class RemainingLifeLimitService {
      * @param updatedRemainingLifeLimitLibrary The remaining life limit library update data
      */
     static updateRemainingLifeLimitLibrary(updatedRemainingLifeLimitLibrary: RemainingLifeLimitLibrary): AxiosPromise {
-        return nodejsAxiosInstance.put('/api/UpdateRemainingLifeLimitLibrary', modifyDataForMongoDB(updatedRemainingLifeLimitLibrary));
+        return nodejsAxiosInstance.put('/api/UpdateRemainingLifeLimitLibrary', modifyDataForMongoDB(updatedRemainingLifeLimitLibrary), {headers: getAuthorizationHeader()});
     }
 
     /**

--- a/BridgeCareApp/VuejsApp/src/services/rollup.service.ts
+++ b/BridgeCareApp/VuejsApp/src/services/rollup.service.ts
@@ -8,7 +8,7 @@ import {getAuthorizationHeader} from '@/shared/utils/authorization-header';
 export default class RollupService {
     static getMongoRollups(): AxiosPromise {
         return new Promise<AxiosResponse<Rollup[]>>((resolve) => {
-            nodejsAxiosInstance.get('api/GetMongoRollups')
+            nodejsAxiosInstance.get('api/GetMongoRollups', {headers: getAuthorizationHeader()})
                 .then((response: AxiosResponse<Rollup[]>) => {
                     if (hasValue(response)) {
                         return resolve(response);
@@ -34,7 +34,7 @@ export default class RollupService {
                         });
 
                         if (resultant.length != 0) {
-                            nodejsAxiosInstance.post('api/AddLegacyNetworks', resultant)
+                            nodejsAxiosInstance.post('api/AddLegacyNetworks', resultant, {headers: getAuthorizationHeader()})
                                 .then((res: AxiosResponse<Rollup[]>) => {
                                     if (hasValue(res)) {
                                         return resolve(res);

--- a/BridgeCareApp/VuejsApp/src/services/scenario.service.ts
+++ b/BridgeCareApp/VuejsApp/src/services/scenario.service.ts
@@ -11,7 +11,7 @@ import {getAuthorizationHeader} from '@/shared/utils/authorization-header';
 export default class ScenarioService {
     static getMongoScenarios(): AxiosPromise {
         return new Promise<AxiosResponse<Scenario[]>>((resolve) => {
-            nodejsAxiosInstance.get('api/GetMongoScenarios')
+            nodejsAxiosInstance.get('api/GetMongoScenarios', {headers: getAuthorizationHeader()})
                 .then((response: AxiosResponse<Scenario[]>) => {
                     if (hasValue(response)) {
                         return resolve(response);
@@ -46,7 +46,7 @@ export default class ScenarioService {
     private static removeMongoScenarios(scenarios: Scenario[]): AxiosPromise {
         return new Promise<AxiosResponse<Scenario[]>>((resolve) => {
             scenarios.forEach(simulation => {
-                nodejsAxiosInstance.delete(`api/DeleteMongoScenario/${(simulation as any)._id}`)
+                nodejsAxiosInstance.delete(`api/DeleteMongoScenario/${(simulation as any)._id}`, {headers: getAuthorizationHeader()})
                     .then((res: AxiosResponse) => {
                         if (hasValue(res)) {
                             return resolve(res);
@@ -73,7 +73,7 @@ export default class ScenarioService {
                                 var scenariosToAdd = this.getMissingScenarios(responseLegacy.data, responseMongo.data);
                                 var scenariosToRemove = this.getMissingScenarios(responseMongo.data, responseLegacy.data);
                                 if (scenariosToAdd.length > 0) {
-                                    nodejsAxiosInstance.post('api/AddMultipleScenarios', scenariosToAdd)
+                                    nodejsAxiosInstance.post('api/AddMultipleScenarios', scenariosToAdd, {headers: getAuthorizationHeader()})
                                         .then((res: AxiosResponse<Scenario[]>) => {
                                             if (hasValue(res)){
                                                 return resolve(res);
@@ -113,7 +113,7 @@ export default class ScenarioService {
                             shared: false,
                             status: 'New scenario'
                         };
-                        nodejsAxiosInstance.post('api/GetMongoScenarios', scenarioToTrackStatus)
+                        nodejsAxiosInstance.post('api/GetMongoScenarios', scenarioToTrackStatus, {headers: getAuthorizationHeader()})
                             .then((res: AxiosResponse<Scenario>) => {
                                 if (hasValue(res)) {
                                     return resolve(res);
@@ -140,7 +140,7 @@ export default class ScenarioService {
                 .then((response: AxiosResponse<Scenario>) => {
                     if (hasValue(response)) {
 
-                        nodejsAxiosInstance.put(`api/UpdateMongoScenario/${scenarioId}`, scenarioUpdateData)
+                        nodejsAxiosInstance.put(`api/UpdateMongoScenario/${scenarioId}`, scenarioUpdateData, {headers: getAuthorizationHeader()})
                             .then((res: AxiosResponse<Scenario>) => {
                                 if (hasValue(res)) {
                                     return resolve(res);
@@ -166,7 +166,7 @@ export default class ScenarioService {
             axiosInstance.delete(`/api/DeleteScenario/${scenarioId}`, {headers: getAuthorizationHeader()})
                 .then((serverResponse: AxiosResponse) => {
                     if (hasValue(serverResponse, 'status') && http2XX.test(serverResponse.status.toString())) {
-                        nodejsAxiosInstance.delete(`api/DeleteMongoScenario/${scenarioMongoId}`)
+                        nodejsAxiosInstance.delete(`api/DeleteMongoScenario/${scenarioMongoId}`, {headers: getAuthorizationHeader()})
                             .then((mongoResponse: AxiosResponse) => {
                                 return resolve(mongoResponse);
                             })

--- a/BridgeCareApp/VuejsApp/src/services/target.service.ts
+++ b/BridgeCareApp/VuejsApp/src/services/target.service.ts
@@ -25,7 +25,7 @@ export default class TargetService {
      * Gets target libraries data
      */
     static getTargetLibraries(): AxiosPromise {
-        return nodejsAxiosInstance.get('/api/GetTargetLibraries');
+        return nodejsAxiosInstance.get('/api/GetTargetLibraries', {headers: getAuthorizationHeader()});
     }
 
     /**
@@ -33,7 +33,7 @@ export default class TargetService {
      * @param createdTargetLibrary The target library create data
      */
     static createTargetLibrary(createdTargetLibrary: TargetLibrary): AxiosPromise {
-        return nodejsAxiosInstance.post('/api/CreateTargetLibrary', modifyDataForMongoDB(createdTargetLibrary));
+        return nodejsAxiosInstance.post('/api/CreateTargetLibrary', modifyDataForMongoDB(createdTargetLibrary), {headers: getAuthorizationHeader()});
     }
 
     /**
@@ -41,7 +41,7 @@ export default class TargetService {
      * @param updatedTargetLibrary The target library update data
      */
     static updateTargetLibrary(updatedTargetLibrary: TargetLibrary): AxiosPromise {
-        return nodejsAxiosInstance.put('/api/UpdateTargetLibrary', modifyDataForMongoDB(updatedTargetLibrary));
+        return nodejsAxiosInstance.put('/api/UpdateTargetLibrary', modifyDataForMongoDB(updatedTargetLibrary), {headers: getAuthorizationHeader()});
     }
 
     /**

--- a/BridgeCareApp/VuejsApp/src/services/treatment-editor.service.ts
+++ b/BridgeCareApp/VuejsApp/src/services/treatment-editor.service.ts
@@ -46,7 +46,7 @@ export default class TreatmentEditorService {
      * Gets all treatment libraries
      */
     static getTreatmentLibraries(): AxiosPromise {
-        return nodejsAxiosInstance.get('/api/GetTreatmentLibraries');
+        return nodejsAxiosInstance.get('/api/GetTreatmentLibraries', {headers: getAuthorizationHeader()});
     }
 
     /**
@@ -54,7 +54,7 @@ export default class TreatmentEditorService {
      * @param createTreatmentLibraryData The treatment library create data
      */
     static createTreatmentLibrary(createTreatmentLibraryData: TreatmentLibrary): AxiosPromise {
-        return nodejsAxiosInstance.post('/api/CreateTreatmentLibrary', modifyDataForMongoDB(createTreatmentLibraryData));
+        return nodejsAxiosInstance.post('/api/CreateTreatmentLibrary', modifyDataForMongoDB(createTreatmentLibraryData), {headers: getAuthorizationHeader()});
     }
 
     /**
@@ -62,7 +62,7 @@ export default class TreatmentEditorService {
      * @param updateTreatmentLibraryData The treatment library update data
      */
     static updateTreatmentLibrary(updateTreatmentLibraryData: TreatmentLibrary): AxiosPromise {
-        return nodejsAxiosInstance.put('/api/UpdateTreatmentLibrary', modifyDataForMongoDB(updateTreatmentLibraryData));
+        return nodejsAxiosInstance.put('/api/UpdateTreatmentLibrary', modifyDataForMongoDB(updateTreatmentLibraryData), {headers: getAuthorizationHeader()});
     }
 
     /**

--- a/BridgeCareApp/VuejsApp/src/shared/utils/authorization-header.ts
+++ b/BridgeCareApp/VuejsApp/src/shared/utils/authorization-header.ts
@@ -4,5 +4,5 @@ import store from '@/store/root-store';
  * Creates a header to send with all calls to the C# api
  */
 export const getAuthorizationHeader = () => {
-    return {'Authorization': 'Bearer ' + (store.state as any).authentication.userAccessToken};
+    return {'Authorization': 'Bearer ' + (store.state as any).authentication.userIdToken};
 };

--- a/BridgeCareApp/VuejsApp/src/store-modules/authentication.module.ts
+++ b/BridgeCareApp/VuejsApp/src/store-modules/authentication.module.ts
@@ -28,12 +28,12 @@ const actions = {
             });
     },
 
-    async refreshAccessToken({commit, dispatch}: any) {
+    async refreshTokens({commit, dispatch}: any) {
         if (!localStorage.getItem('UserTokens')) {
             dispatch('logOut');
         } else {
             const userTokens: UserTokens = JSON.parse(localStorage.getItem('UserTokens') as string) as UserTokens;
-            await AuthenticationService.refreshAccessToken(userTokens.refresh_token)
+            await AuthenticationService.refreshTokens(userTokens.refresh_token)
                 .then((response: AxiosResponse<string>) => {
                     if (http2XX.test(response.status.toString())) {
                         localStorage.setItem('UserTokens', JSON.stringify({


### PR DESCRIPTION
- RestrictAccessAttribute now allows roles to be specified
- Role authorization in accordance with "Intermediate" spreadsheet
  - Read-only access is available to all users
  - Full access is available to administrators and bridge engineers
  - Authorization is implemented for both Node and C# apis
- Authorization uses ID tokens instead of frequent calls to the ESEC API with access tokens