### PR TITLE
vnext/530 - On loading, check local storage for previous login

### DIFF
--- a/BridgeCareApp/VuejsApp/src/App.vue
+++ b/BridgeCareApp/VuejsApp/src/App.vue
@@ -107,6 +107,7 @@
         @State(state => state.scenario.selectedScenarioName) stateSelectedScenarioName: string;
 
         @Action('refreshTokens') refreshTokensAction: any;
+        @Action('checkBrowserTokens') checkBrowserTokensAction: any;
         @Action('logOut') logOutAction: any;
         @Action('setIsBusy') setIsBusyAction: any;
         @Action('getNetworks') getNetworksAction: any;
@@ -206,6 +207,11 @@
                 (response: any) => successHandler(response),
                 (error: any) => errorHandler(error)
             );
+
+            // Upon opening the page, and every 30 seconds, check if authentication data
+            // has been changed by another tab or window
+            this.checkBrowserTokensAction();
+            window.setInterval(this.checkBrowserTokensAction, 30000);
 
             // Every 29 minutes, all tokens will be refreshed if a user is logged in.
             // Tokens last 30 minutes


### PR DESCRIPTION
 - Users do not need to log in for each tab or window they open
 - Users do not need to log in again if they have not logged out in the last half hour
 - Login persists through browser refresh
 - When a user logs in or out on one tab, all other tabs will update to reflect this change within 30 seconds