### PR TITLE
vnext/554 - Socket.io and refresh

### DIFF
--- a/BridgeCareApp/VuejsApp/.env.development
+++ b/BridgeCareApp/VuejsApp/.env.development
@@ -1,4 +1,5 @@
 ﻿VUE_APP_URL = http://localhost:50696
 VUE_APP_NODE_URL = http://localhost:4000
+VUE_APP_SOCKET_PATH = /socket.io
 
 VUE_APP_IS_PRODUCTION = "false"

--- a/BridgeCareApp/VuejsApp/.env.production
+++ b/BridgeCareApp/VuejsApp/.env.production
@@ -1,4 +1,5 @@
-﻿VUE_APP_URL = https://iam-bridgecare-apis.dev.penndot.gov
-VUE_APP_NODE_URL = https://iam-bridgecare-node.dev.penndot.gov
+﻿VUE_APP_URL = https://www.bamsdev.penndot.gov/apis
+VUE_APP_NODE_URL = https://www.bamsdev.penndot.gov/node
+VUE_APP_SOCKET_PATH = /node/socket.io
 
 VUE_APP_IS_PRODUCTION = "true"

--- a/BridgeCareApp/VuejsApp/.env.staging
+++ b/BridgeCareApp/VuejsApp/.env.staging
@@ -2,5 +2,6 @@ NODE_ENV="production"
 
 VUE_APP_URL = https://apis.iam-deploy.com/
 VUE_APP_NODE_URL = https://node-apis.iam-deploy.com
+VUE_APP_SOCKET_PATH = /socket.io
 
 VUE_APP_IS_PRODUCTION = "true"

--- a/BridgeCareApp/VuejsApp/src/main.ts
+++ b/BridgeCareApp/VuejsApp/src/main.ts
@@ -20,7 +20,12 @@ Vue.use(Vuetify, {
     iconfont: 'fa'
 });
 
-Vue.use(VueSocketio, io(process.env.VUE_APP_NODE_URL), { store });
+Vue.use(VueSocketio, 
+    io(process.env.VUE_APP_NODE_URL, 
+        {
+            path: (process.env.VUE_APP_NODE_URL.indexOf('penndot.gov') === -1) ? '/socket.io' : '/node/socket.io'
+        }), 
+    { store });
 
 Vue.use(VueWorker);
 

--- a/BridgeCareApp/VuejsApp/src/main.ts
+++ b/BridgeCareApp/VuejsApp/src/main.ts
@@ -20,12 +20,9 @@ Vue.use(Vuetify, {
     iconfont: 'fa'
 });
 
-Vue.use(VueSocketio, 
-    io(process.env.VUE_APP_NODE_URL, 
-        {
-            path: (process.env.VUE_APP_NODE_URL.indexOf('penndot.gov') === -1) ? '/socket.io' : '/node/socket.io'
-        }), 
-    { store });
+const socketioClient = io(process.env.VUE_APP_NODE_URL, { path: process.env.VUE_APP_SOCKET_PATH });
+
+Vue.use(VueSocketio, socketioClient, { store });
 
 Vue.use(VueWorker);
 

--- a/BridgeCareApp/VuejsApp/src/store-modules/authentication.module.ts
+++ b/BridgeCareApp/VuejsApp/src/store-modules/authentication.module.ts
@@ -39,9 +39,8 @@ const actions = {
             if (state.authenticated) {
                 return;
             }
+            dispatch('refreshTokens').then(() => dispatch('getUserInfo'));
             commit('authenticatedMutator', true);
-            dispatch('refreshTokens');
-            dispatch('getUserInfo');
         } else if (state.authenticated) {
             dispatch('logOut');
         }


### PR DESCRIPTION
 - Socket.io was stripping the path away from the URI it was given. It must be given the path explicitly in its configuration.
 - Upon refreshing the page, there was a race condition between the tasks of refreshing the old tokens and using the new tokens to get user info. These now take place sequentially.