### PR TITLE
vnext/554 - Restrict access to RunSimulation endpoint

### DIFF
--- a/BridgeCareApp/BridgeCare/Controllers/SimulationController.cs
+++ b/BridgeCareApp/BridgeCare/Controllers/SimulationController.cs
@@ -78,7 +78,7 @@ namespace BridgeCare.Controllers
         /// <returns>IHttpActionResult</returns>
         [HttpPost]
         [Route("api/RunSimulation")]
-        [RestrictAccess]
+        [RestrictAccess(Role.ADMINISTRATOR, Role.DISTRICT_ENGINEER)]
         public async Task<IHttpActionResult> RunSimulation([FromBody]SimulationModel model)
         {
             var result = await Task.Factory.StartNew(() => repo.RunSimulation(model));


### PR DESCRIPTION
 - Only allow Administrators and DBEngineers to run simulations