### PR TITLE
vnext/576 - Add deployment script to repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -347,3 +347,15 @@ connection.config
 # ESEC metadata, including client secret
 /BridgeCareApp/BridgeCare/esec.config
 /BridgeCareApp/BridgeCare/Logs/BridgeCareAPI.log
+
+# Deployment packages
+/Deployment/Deployment_Packages
+
+# Deployment configurations that include client_secret
+/Deployment/configurations/bams/esec.config
+/Deployment/configurations/bamsdev/esec.config
+/Deployment/configurations/bamssyst/esec.config
+/Deployment/configurations/iam-deploy/esec.config
+
+# Deployment logs
+/Deployment/npmLogs

--- a/Deployment/configurations/bams/.env.production
+++ b/Deployment/configurations/bams/.env.production
@@ -1,0 +1,6 @@
+VUE_APP_URL = https://www.bams.penndot.gov/apis
+VUE_APP_NODE_URL = https://www.bams.penndot.gov/node
+VUE_APP_SOCKET_URL = ws://www.bams.penndot.gov
+VUE_APP_SOCKET_PATH = /node/socket.io
+
+VUE_APP_IS_PRODUCTION = "true"

--- a/Deployment/configurations/bams/authorizationConfig.js
+++ b/Deployment/configurations/bams/authorizationConfig.js
@@ -1,0 +1,13 @@
+const authorizationConfig = {
+    esecPublicKey: {
+        "kty": "RSA",
+        "e": "AQAB",
+        "use": "sig",
+        "kid": "6b00ffec-d51c-435b-867f-7c870ee6945c",
+        "n": "sVBdiGSCsAXigGHn1KZej4aqnjZrgimUIRtL7VWx6VzEJ9fu8JsDiwx_cGkRuettINdYM9U4_akuJqITwSsTIv_VhJRYprVZJChlwObKVPLmPEs4oa4Wuk6Iy81P4jg2-7GV37ScOyD4rxxhff4F-Kh5MflYZpPUYjjJkaJcJVs"
+    },
+    issuer: 'https://oidcservices.penndot.gov/affwebservices/CASSO/oidc/BAMS',
+    clientId: '37db8371-3f80-45d4-a4bd-48c080b2865a'
+};
+
+module.exports = authorizationConfig;

--- a/Deployment/configurations/bams/oidc-config.ts
+++ b/Deployment/configurations/bams/oidc-config.ts
@@ -1,0 +1,7 @@
+const oidcConfig: any = {
+    authorizationEndpoint: 'https://oidcservices.penndot.gov/affwebservices/CASSO/oidc/BAMS/authorize',
+    clientId: '37db8371-3f80-45d4-a4bd-48c080b2865a',
+    redirectUri: 'https://www.bams.penndot.gov/Authentication/'
+};
+
+export default oidcConfig;

--- a/Deployment/configurations/bamsdev/.env.production
+++ b/Deployment/configurations/bamsdev/.env.production
@@ -1,0 +1,6 @@
+VUE_APP_URL = https://www.bamsdev.penndot.gov/apis
+VUE_APP_NODE_URL = https://www.bamsdev.penndot.gov/node
+VUE_APP_SOCKET_URL = ws://www.bamsdev.penndot.gov
+VUE_APP_SOCKET_PATH = /node/socket.io
+
+VUE_APP_IS_PRODUCTION = "true"

--- a/Deployment/configurations/bamsdev/oidc-config.ts
+++ b/Deployment/configurations/bamsdev/oidc-config.ts
@@ -1,0 +1,7 @@
+const oidcConfig: any = {
+    authorizationEndpoint: 'https://oidcservicessyst.penndot.gov/affwebservices/CASSO/oidc/BAMS/authorize',
+    clientId: 'a56bb9d5-190d-4873-afea-0767d82dd91c',
+    redirectUri: 'https://www.bamsdev.penndot.gov/Authentication/'
+};
+
+export default oidcConfig;

--- a/Deployment/configurations/bamssyst/.env.production
+++ b/Deployment/configurations/bamssyst/.env.production
@@ -1,0 +1,6 @@
+VUE_APP_URL = https://www.bamssyst.penndot.gov/apis
+VUE_APP_NODE_URL = https://www.bamssyst.penndot.gov/node
+VUE_APP_SOCKET_URL = ws://www.bamssyst.penndot.gov
+VUE_APP_SOCKET_PATH = /node/socket.io
+
+VUE_APP_IS_PRODUCTION = "true"

--- a/Deployment/configurations/bamssyst/oidc-config.ts
+++ b/Deployment/configurations/bamssyst/oidc-config.ts
@@ -1,0 +1,7 @@
+const oidcConfig: any = {
+    authorizationEndpoint: 'https://oidcservicessyst.penndot.gov/affwebservices/CASSO/oidc/BAMS/authorize',
+    clientId: 'a56bb9d5-190d-4873-afea-0767d82dd91c',
+    redirectUri: 'https://www.bamssyst.penndot.gov/Authentication/'
+};
+
+export default oidcConfig;

--- a/Deployment/configurations/iam-deploy/oidc-config.ts
+++ b/Deployment/configurations/iam-deploy/oidc-config.ts
@@ -1,0 +1,7 @@
+const oidcConfig: any = {
+    authorizationEndpoint: 'https://oidcservicessyst.penndot.gov/affwebservices/CASSO/oidc/BAMS/authorize',
+    clientId: 'a56bb9d5-190d-4873-afea-0767d82dd91c',
+    redirectUri: 'https://iam-deploy.com/Authentication/'
+};
+
+export default oidcConfig;

--- a/Deployment/deploy.ps1
+++ b/Deployment/deploy.ps1
@@ -1,0 +1,292 @@
+# === Configuration === #
+$deploymentScriptPath = Get-Location;
+$iamRepoPath = (Get-Item $deploymentScriptPath).parent.FullName;
+$deploymentOutputPath = "$deploymentScriptPath\Deployment_Packages";
+$configurations = "$deploymentScriptPath\configurations";
+$npmLogPath = "$deploymentScriptPath\npmLogs";
+# === End Configuration === #
+
+Clear-Host;
+
+Write-Host "This script will create a deployment package for PennDOT and for iAM-deploy.";
+Write-Host "The package will include fully-configured packages for all environments.`n`n";
+
+Write-Host "The iAM repo is located at:`n    $iamRepoPath`n";
+Write-Host "The deployment package will be at:`n    $deploymentOutputPath`n";
+Write-Host "This script is located at`n    $deploymentScriptPath`n";
+Write-Host "The logs from the latest VueJS app deployments can be found at`n    $npmLogPath`n";
+
+Write-Host "Warning: This script does not compile the C# app! You must publish it manually from Visual Studio." -ForegroundColor Yellow -BackgroundColor Red;
+Write-Host "This script packages Visual Studio's output into a fully-configured deployment package." -ForegroundColor Yellow -BackgroundColor Red;
+
+$cSharpBuiltConfirmation = Read-Host 'Confirm that you have published the C# app by typing "confirm" here';
+
+If ($cSharpBuiltConfirmation -ne 'confirm') {
+    exit;
+}
+
+$version = Read-Host -Prompt 'Input the version name for this deployment. (Ex. "12192019")';
+
+$startTimeSeconds = (Get-Date).Second;
+$startTimeMinutes = (Get-Date).Minute;
+
+$devPath = "$deploymentOutputPath\dev\$version\";
+$systPath = "$deploymentOutputPath\syst\$version\";
+$prodPath = "$deploymentOutputPath\prod\$version\";
+$iamDeployPath = "$deploymentOutputPath\iam-deploy\$version\";
+
+# === Make sure npm log folder exists === #
+
+If (Test-Path $npmLogPath) {
+    Remove-Item $npmLogPath -Recurse *>$null;
+}
+New-Item -Path $npmLogPath -ItemType Directory *>$null;
+
+# === Make sure deploymentOutputPath and its subfolders exist === #
+
+If (-Not (Test-Path "$deploymentOutputPath")) {
+    New-Item -Path "$deploymentOutputPath" -ItemType Directory *>$null;
+}
+If (-Not (Test-Path "$deploymentOutputPath\dev")) {
+    New-Item -Path "$deploymentOutputPath\dev" -ItemType Directory *>$null;
+}
+If (-Not (Test-Path "$deploymentOutputPath\syst")) {
+    New-Item -Path "$deploymentOutputPath\syst" -ItemType Directory *>$null;
+}
+If (-Not (Test-Path "$deploymentOutputPath\prod")) {
+    New-Item -Path "$deploymentOutputPath\prod" -ItemType Directory *>$null;
+}
+If (-Not (Test-Path "$deploymentOutputPath\iam-deploy")) {
+    New-Item -Path "$deploymentOutputPath\iam-deploy" -ItemType Directory *>$null;
+}
+
+# === Remove any duplicate deployment, create folders for new deployment === #
+
+If (Test-Path $devPath) {
+    Remove-Item $devPath -Recurse *>$null;
+}
+New-Item -Path $devPath `
+    -ItemType Directory *>$null;
+New-Item -Path "$devPath\VueJS" `
+    -ItemType Directory *>$null;
+New-Item -Path "$devPath\NodeJS" `
+    -ItemType Directory *>$null;
+New-Item -Path "$devPath\C#" `
+    -ItemType Directory *>$null;
+If (Test-Path $systPath) {
+    Remove-Item $systPath -Recurse *>$null;
+}
+New-Item -Path $systPath `
+    -ItemType Directory *>$null;
+New-Item -Path "$systPath\VueJS" `
+    -ItemType Directory *>$null;
+New-Item -Path "$systPath\NodeJS" `
+    -ItemType Directory *>$null;
+New-Item -Path "$systPath\C#" `
+    -ItemType Directory *>$null;
+If (Test-Path $prodPath) {
+    Remove-Item $prodPath -Recurse *>$null;
+}
+New-Item -Path $prodPath `
+    -ItemType Directory *>$null;
+New-Item -Path "$prodPath\VueJS" `
+    -ItemType Directory *>$null;
+New-Item -Path "$prodPath\NodeJS" `
+    -ItemType Directory *>$null;
+New-Item -Path "$prodPath\C#" `
+    -ItemType Directory *>$null;
+If (Test-Path $iamDeployPath) {
+    Remove-Item $iamDeployPath -Recurse *>$null;
+}
+New-Item -Path $iamDeployPath `
+    -ItemType Directory *>$null;
+New-Item -Path "$iamDeployPath\VueJS" `
+    -ItemType Directory *>$null;
+New-Item -Path "$iamDeployPath\NodeJS" `
+    -ItemType Directory *>$null;
+New-Item -Path "$iamDeployPath\C#" `
+    -ItemType Directory *>$null;
+
+Clear-Host
+
+Write-Host "Beginning deployment: $version`n"
+
+# ======================================= C# ======================================= #
+
+Write-Host '===== Beginning C# Deployments =====' -ForegroundColor White;
+
+Set-Location "$iamRepoPath\BridgeCareApp\BridgeCare\bin\release";
+
+Write-Host 'Removing PCI Files...' -ForegroundColor Yellow;
+
+If (Test-Path ".\publish\bin\PCI.dll") {
+    Remove-Item ".\publish\bin\PCI.dll";
+}
+If (Test-Path ".\publish\bin\PCI.pdb") {
+    Remove-Item ".\publish\bin\PCI.pdb";
+}
+
+$cSharpExclusions = "connection.config", "esec.config";
+
+Write-Host 'Copying C# App...' -ForegroundColor Yellow;
+
+Copy-Item -Path `
+    (Get-Item -Path ".\publish\*" -Exclude $cSharpExclusions).FullName `
+    -Destination "$devPath\C#" -Recurse -Force;
+
+Copy-Item -Path `
+    (Get-Item -Path ".\publish\*" -Exclude $cSharpExclusions).FullName `
+    -Destination "$systPath\C#" -Recurse -Force;
+
+Copy-Item -Path `
+    (Get-Item -Path ".\publish\*" -Exclude $cSharpExclusions).FullName `
+    -Destination "$prodPath\C#" -Recurse -Force;
+
+Copy-Item -Path `
+    (Get-Item -Path ".\publish\*" -Exclude $cSharpExclusions).FullName `
+    -Destination "$iamDeployPath\C#" -Recurse -Force;
+
+Write-Host 'Setting ESEC Configurations...' -ForegroundColor Yellow;
+
+Copy-Item "$configurations\bamsdev\esec.config" `
+    -Destination "$devPath\C#\esec.config";
+
+Copy-Item "$configurations\bamssyst\esec.config" `
+    -Destination "$systPath\C#\esec.config";
+
+Copy-Item "$configurations\bams\esec.config" `
+    -Destination "$prodPath\C#\esec.config";
+
+Copy-Item "$configurations\iam-deploy\esec.config" `
+    -Destination "$iamDeployPath\C#\esec.config";
+
+Write-Host "C# Deployments Completed.`n" -ForegroundColor Green;
+
+# ======================================= NODE ======================================= #
+
+Write-Host '===== Beginning Node Deployments =====' -ForegroundColor White;
+
+Set-Location "$iamRepoPath\BridgeCareApp";
+
+$nodeExclusions = ".vscode", "node_modules";
+
+Write-Host 'Beginning "bamsdev" NodeJS Deployment...' -ForegroundColor Yellow;
+
+Copy-Item -Path `
+    (Get-Item -Path ".\BridgeCareNodeApp\*" -Exclude $nodeExclusions).FullName `
+    -Destination "$devPath\NodeJS" -Recurse -Force;
+
+Write-Host 'Completed "bamsdev" NodeJS Deployment.' -ForegroundColor Green;
+
+Write-Host 'Beginning "bamssyst" NodeJS Deployment...' -ForegroundColor Yellow;
+
+Copy-Item -Path `
+    (Get-Item -Path ".\BridgeCareNodeApp\*" -Exclude $nodeExclusions).FullName `
+    -Destination "$systPath\NodeJS" -Recurse -Force;
+
+Write-Host 'Completed "bamssyst" NodeJS Deployment.' -ForegroundColor Green;
+
+Write-Host 'Beginning "bams" [PROD] NodeJS Deployment...' -ForegroundColor Yellow;
+
+Copy-Item -Path `
+    (Get-Item -Path ".\BridgeCareNodeApp\*" -Exclude $nodeExclusions).FullName `
+    -Destination "$prodPath\NodeJS" -Recurse -Force;
+
+Write-Host 'Configuring "bams" [PROD] NodeJS Deployment...' -ForegroundColor Yellow;
+
+Remove-Item "$prodPath\NodeJS\authorization\authorizationConfig.js";
+
+Copy-Item -Path "$configurations\bams\authorizationConfig.js" `
+    -Destination "$prodPath\NodeJS\authorization";
+
+Write-Host 'Completed "bams" [PROD] NodeJS Deployment.' -ForegroundColor Green;
+
+Write-Host 'Beginning "iAM-deploy" NodeJS Deployment...' -ForegroundColor Yellow;
+
+Copy-Item -Path `
+    (Get-Item -Path ".\BridgeCareNodeApp\*" -Exclude $nodeExclusions).FullName `
+    -Destination "$iamDeployPath\NodeJS" -Recurse -Force;
+
+Write-Host 'Completed "iAM-deploy" NodeJS Deployment.' -ForegroundColor Green;
+
+Write-Host "NodeJS Deployments Completed.`n" -ForegroundColor Green;
+
+# ======================================= VUE ======================================= #
+
+Write-Host '===== Beginning VueJS Deployments =====' -ForegroundColor White;
+
+Set-Location "$iamRepoPath\BridgeCareApp\VuejsApp";
+
+# === bamsdev ===
+Write-Host 'Beginning "bamsdev" VueJS Deployment...' -ForegroundColor Yellow;
+
+Copy-Item "$configurations\bamsdev\.env.production" `
+    -Destination ".\.env.production";
+Copy-Item "$configurations\bamsdev\oidc-config.ts" `
+    -Destination ".\src\oidc-config.ts";
+
+Write-Host "Building app... Build log can be found at`n$npmLogPath\bamsdev.txt" -ForegroundColor Yellow;
+npm run build-prod *> $npmLogPath\bamsdev.txt;
+
+Copy-Item -Path ".\dist\*" `
+    -Destination "$devPath\VueJS" `
+    -Recurse;
+
+Write-Host 'Completed "bamsdev" VueJS Deployment...' -ForegroundColor Green;
+
+# === bamssyst ===
+Write-Host 'Beginning "bamssyst" VueJS Deployment...' -ForegroundColor Yellow;
+
+Copy-Item "$configurations\bamssyst\.env.production" `
+    -Destination ".\.env.production";
+Copy-Item "$configurations\bamssyst\oidc-config.ts" `
+    -Destination ".\src\oidc-config.ts";
+
+Write-Host "Building app... Build log can be found at`n$npmLogPath\bamssyst.txt" -ForegroundColor Yellow;
+npm run build-prod *> $npmLogPath\bamssyst.txt;
+
+Copy-Item -Path ".\dist\*" `
+    -Destination "$systPath\VueJS" `
+    -Recurse;
+
+Write-Host 'Completed "bamssyst" VueJS Deployment...' -ForegroundColor Green;
+
+# === bams [PROD] ===
+Write-Host 'Beginning "bams" [PROD] VueJS Deployment...' -ForegroundColor Yellow;
+
+Copy-Item "$configurations\bams\.env.production" `
+    -Destination ".\.env.production";
+Copy-Item "$configurations\bams\oidc-config.ts" `
+    -Destination ".\src\oidc-config.ts";
+
+Write-Host "Building app... Build log can be found at`n$npmLogPath\bams.txt" -ForegroundColor Yellow;
+npm run build-prod *> $npmLogPath\bams.txt;
+
+Copy-Item -Path ".\dist\*" `
+    -Destination "$prodPath\VueJS" `
+    -Recurse;
+
+Write-Host 'Completed "bams" [PROD] VueJS Deployment...' -ForegroundColor Green;
+
+# === iAM-deploy ===
+Write-Host 'Beginning "iAM-deploy" VueJS Deployment...' -ForegroundColor Yellow;
+
+# iam-deploy build does not require a change to .env.production, as it uses .env.staging
+Copy-Item "$configurations\iam-deploy\oidc-config.ts" `
+    -Destination ".\src\oidc-config.ts";
+
+Write-Host "Building app... Build log can be found at`n$npmLogPath\iam-deploy.txt" -ForegroundColor Yellow;
+npm run stage *> $npmLogPath\iam-deploy.txt;
+
+Copy-Item -Path ".\dist\*" `
+    -Destination "$iamDeployPath\VueJS" `
+    -Recurse;
+
+Write-Host 'Completed "iAM-deploy" VueJS Deployment...' -ForegroundColor Green;
+
+Write-Host "VueJS Deployments Completed`n" -ForegroundColor Green;
+
+$endTimeSeconds = (Get-Date).Second;
+$endTimeMinutes = (Get-Date).Minute;
+
+Read-Host -Prompt "Finished in $($endTimeMinutes - $startTimeMinutes) minutes $($endTimeSeconds - $startTimeSeconds) seconds.";

--- a/Deployment/readme.txt
+++ b/Deployment/readme.txt
@@ -1,0 +1,13 @@
+To use the deployment script, first you need to place the appropriate esec.config files in the 
+configurations/bams, configurations/bamsdev, configurations/bamssyst, configurations/iam-deploy folders.
+
+Then, make sure to publish the C# app in visual studio.
+
+Finally, right click the deployment script, deploy.ps1, and select "Run with PowerShell".
+
+The script will ask you to confirm that you have published the C# app, and will ask for a name for the
+deployment. 
+
+The script will then run for 1 - 3 minutes, and when it is done, each of the folders in the Deployment_Packages
+folder (dev, syst, prod, iam-deploy) will contain a folder with the specified name, containing the deployment
+package for that environment.


### PR DESCRIPTION
- Automates the full app configuration process and vue app build process
- esec.config files must be manually added, since client_id cannot be stored on a public repo


If you use this script and then switch to a branch that has not yet had these changes merged into it, you will need to update that branch's .gitignore to avoid uploading your deployment packages to the repo.