### PR TITLE
vnext/644: Criteria Editor Selected Conjunction Fix

### DIFF
--- a/BridgeCareApp/VuejsApp/src/shared/modals/CriteriaEditorDialog.vue
+++ b/BridgeCareApp/VuejsApp/src/shared/modals/CriteriaEditorDialog.vue
@@ -176,6 +176,7 @@
             if (this.mainCriteria && isEmpty(this.mainCriteria.logicalOperator)) {
                 this.mainCriteria.logicalOperator = 'OR';
             }
+            this.selectedConjunction = this.mainCriteria.logicalOperator;
         }
 
         /**


### PR DESCRIPTION
-fixed bug where incorrect conjunction was being used when parsing a criteria string that has a logical operator