### PR TITLE
vnext/634

### DIFF
--- a/BridgeCareApp/VuejsApp/src/components/scenarios/Scenarios.vue
+++ b/BridgeCareApp/VuejsApp/src/components/scenarios/Scenarios.vue
@@ -69,7 +69,7 @@
                         <td>{{formatDate(props.item.createdDate)}}</td>
                         <td>{{formatDate(props.item.lastModifiedDate)}}</td>
                         <td>{{props.item.status}}</td>
-                        <td style="width: 1px">
+                        <td>
                             <v-layout row nowrap>
                                 <v-flex>
                                     <v-btn icon class="ara-blue" @click="onShowRunSimulationAlert(props.item)"
@@ -152,7 +152,7 @@
                         <td>{{formatDate(props.item.createdDate)}}</td>
                         <td>{{formatDate(props.item.lastModifiedDate)}}</td>
                         <td>{{props.item.status}}</td>
-                        <td style="width: 1px">
+                        <td>
                             <v-layout row nowrap>
                                 <v-flex>
                                     <v-btn flat icon class="ara-blue" @click="onShowRunSimulationAlert(props.item)"


### PR DESCRIPTION
- Width restriction caused rows to be forced into columns on production builds, but only sometimes