### PR TITLE
vnext/659 - Webpack delimiter

### DIFF
--- a/BridgeCareApp/VuejsApp/vue.config.js
+++ b/BridgeCareApp/VuejsApp/vue.config.js
@@ -5,6 +5,7 @@ module.exports = {
             splitChunks: {
                 chunks: 'all',
                 maxInitialRequests: Infinity,
+                automaticNameDelimiter: '_',
                 cacheGroups: {
                     vendor: {
                         test: /[\\/]node_modules[\\/]/,


### PR DESCRIPTION
Change webpack's filename delimiter to '_' from '~'