### PR TITLE
vnext/681 - Remove invalid spaces before parsing criteria

### DIFF
--- a/BridgeCareApp/VuejsApp/src/shared/utils/criteria-editor-parsers.ts
+++ b/BridgeCareApp/VuejsApp/src/shared/utils/criteria-editor-parsers.ts
@@ -92,22 +92,26 @@ function parseQueryBuilderRule(criteriaRule: CriteriaRule) {
  * @param clause The clause string to parse
  */
 export const parseCriteriaString = (clause: string) => {
+    console.log(clause);
     try {
         if (hasValue(clause)) {
+            var trimmedClause: string = clause.trim();
+            // Whenever any of the following operands (or space) are followed by an extra space, trim away that space
+            trimmedClause = trimmedClause.replace(/ *([ <>=]) */g, (_, group1) => group1);
             // create a new criteria object
             const newCriteria: Criteria = {
                 logicalOperator: '',
                 children: []
             };
             // if no open parentheses are present, assume clause string was created in legacy app
-            if ((clause.match(/\(/g) || []).length === 0) {
+            if ((trimmedClause.match(/\(/g) || []).length === 0) {
                 // ensure there are no close parentheses in the string before parsing
-                clause = clause.replace(/\)/g, '');
+                trimmedClause = trimmedClause.replace(/\)/g, '');
                 // parse the clause string and return
-                return parseLegacyAppClause(clause, newCriteria);
+                return parseLegacyAppClause(trimmedClause, newCriteria);
             } else {
                 // parse the clause as a query builder string and return
-                return parseQueryBuilderClause(clause, newCriteria);
+                return parseQueryBuilderClause(trimmedClause, newCriteria);
             }
         }
     }


### PR DESCRIPTION
The criteria that isn't loading properly on bamssyst contains doubled spaces and has invalid spaces in between operators and their operands.
The parser now trims away such spaces before attempting to parse the criteria.