### PR TITLE
#691: Add ability to have a blank amount for cash flow amount

### DIFF
--- a/BridgeCareApp/VuejsApp/src/components/cash-flow-editor/CashFlowEditor.vue
+++ b/BridgeCareApp/VuejsApp/src/components/cash-flow-editor/CashFlowEditor.vue
@@ -110,7 +110,9 @@
                                         <td>
                                             <v-edit-dialog :return-value.sync="props.item.amount" large lazy persistent full-width
                                                            @save="onEditSelectedLibraryListData(props.item, 'amount')">
-                                                <input class="output" type="text" readonly :value="formatAsCurrency(props.item.amount)"
+                                                <input v-if="props.item.amount === null || props.item.amount === undefined || props.item.amount === ''"
+                                                       class="output" type="text" readonly :value="props.item.amount" />
+                                                <input v-else class="output" type="text" readonly :value="formatAsCurrency(props.item.amount)"
                                                        :class="{'invalid-input':splitTreatmentLimitAmountNotLessThanPreviousAmount(props.item) !== true}" />
                                                 <template slot="input">
                                                     <v-text-field v-model.number="props.item.amount" label="Edit" single-line
@@ -430,7 +432,7 @@
                 return clone({
                     ...newSplitTreatmentLimit,
                     rank: newRank,
-                    amount: newSplitTreatmentLimit.amount < newAmount ? newAmount : newSplitTreatmentLimit.amount,
+                    amount: newSplitTreatmentLimit.amount! < newAmount ? newAmount : newSplitTreatmentLimit.amount,
                     percentage: newPercentages
                 });
             }
@@ -523,7 +525,7 @@
                             ...this.selectedSplitTreatment,
                             splitTreatmentLimits: update(
                                 findIndex(propEq('id', data.id), this.selectedSplitTreatment.splitTreatmentLimits),
-                                data as SplitTreatmentLimit,
+                                {...data, amount: hasValue(data.amount) ? data.amount : null} as SplitTreatmentLimit,
                                 this.selectedSplitTreatment.splitTreatmentLimits
                             )
                         }),
@@ -615,7 +617,10 @@
         splitTreatmentLimitAmountNotLessThanPreviousAmount(splitTreatmentLimit: SplitTreatmentLimit) {
             const index: number = findIndex(propEq('id', splitTreatmentLimit.id), this.selectedSplitTreatment.splitTreatmentLimits);
             if (index > 0) {
-                return this.selectedSplitTreatment.splitTreatmentLimits[index - 1].amount <= splitTreatmentLimit.amount ||
+                return !hasValue(splitTreatmentLimit.amount) ||
+                    (hasValue(splitTreatmentLimit.amount) && !hasValue(this.selectedSplitTreatment.splitTreatmentLimits[index - 1].amount)) ||
+                    (hasValue(splitTreatmentLimit.amount) && hasValue(this.selectedSplitTreatment.splitTreatmentLimits[index - 1].amount) &&
+                        this.selectedSplitTreatment.splitTreatmentLimits[index - 1].amount! <= splitTreatmentLimit.amount!) ||
                     'This split treatment limit amount must be >= to previous amount';
             }
 

--- a/BridgeCareApp/VuejsApp/src/shared/models/iAM/cash-flow.ts
+++ b/BridgeCareApp/VuejsApp/src/shared/models/iAM/cash-flow.ts
@@ -1,7 +1,7 @@
 export interface SplitTreatmentLimit {
     id: string;
     rank: number;
-    amount: number;
+    amount: number | null;
     percentage: string;
 }
 

--- a/BridgeCareApp/VuejsApp/src/shared/utils/has-value-util.ts
+++ b/BridgeCareApp/VuejsApp/src/shared/utils/has-value-util.ts
@@ -6,11 +6,12 @@ import {isNil, isEmpty} from 'ramda';
  * @param itemProp The item's property to check for a value
  */
 export const hasValue = (item: any, itemProp: string = '') => {
-    const itemHasValue = !isNil(item) && !isEmpty(item);
+    const itemHasValue = item !== null && item !== undefined && item !== '' && item !== [];
 
     let itemPropHasValue = true;
     if (itemHasValue && itemProp !== '') {
-        itemPropHasValue = item.hasOwnProperty(itemProp) && !isNil(item[itemProp]) && !isEmpty(item[itemProp]);
+        itemPropHasValue = item.hasOwnProperty(itemProp) && item[itemProp] !== null && item[itemProp] !== undefined &&
+            item[itemProp] !== '' && item[itemProp] !== [];
     }
 
     return itemHasValue && itemPropHasValue;

--- a/BridgeCareApp/VuejsApp/src/shared/utils/has-value-util.ts
+++ b/BridgeCareApp/VuejsApp/src/shared/utils/has-value-util.ts
@@ -1,5 +1,3 @@
-import {isNil, isEmpty} from 'ramda';
-
 /**
  * Whether or not the specified item has a value (is not null, is not undefined, and is not considered empty)
  * @param item The item to check


### PR DESCRIPTION
-updated hasValue helper function so that it only checks against null, undefined, empty string, and empty array values to determine if an object or property has a value (0s will be considered a value)
-updated SplitTreatmentLimit.amount property to allow nulls
-updated CashFlowEditor to allow empty values for SplitTreatmentLimit amounts