### PR TITLE
vnext/742 - Year 0 investments

### DIFF
--- a/BridgeCareApp/VuejsApp/src/components/investment-editor/InvestmentEditor.vue
+++ b/BridgeCareApp/VuejsApp/src/components/investment-editor/InvestmentEditor.vue
@@ -391,7 +391,6 @@
          * Sets the data table rows using the selected investment library's budgetYears
          */
         setGridData() {
-
             this.budgetYearsGridData = [];
 
             const groupBudgetYearsByYear = groupBy((budgetYear: InvestmentLibraryBudgetYear) => budgetYear.year.toString());
@@ -565,14 +564,23 @@
                                     id: ObjectID.generate(),
                                     year: year,
                                     budgetName: editedBudget.name,
-                                    budgetAmount: 0,
+                                    budgetAmount: 0
                                 });
                             } else {
                                 const editedBudgetYear = currentYearBudgetYears
                                     .find((budgetYear: InvestmentLibraryBudgetYear) =>
                                         budgetYear.budgetName === editedBudget.previousName
                                     ) as InvestmentLibraryBudgetYear;
+                                var defaultBudgetYear = {};
+                                if (editedBudgetYear === undefined) {
+                                    defaultBudgetYear = {
+                                        year: year,
+                                        budgetAmount: 0,
+                                        id: ObjectID.generate()
+                                    };
+                                }
                                 editedBudgetYears.push({
+                                    ...defaultBudgetYear,
                                     ...editedBudgetYear,
                                     budgetName: editedBudget.name
                                 });


### PR DESCRIPTION
- When investment data is missing, it no longer causes an error; instead, default values ($0) are used
- "Year 0" is no longer created