### PR TITLE
vnext/771: (bugfix) Investment editor not saving after editing budget criteria

### DIFF
--- a/BridgeCareApp/VuejsApp/src/shared/modals/EditBudgetsDialog.vue
+++ b/BridgeCareApp/VuejsApp/src/shared/modals/EditBudgetsDialog.vue
@@ -98,11 +98,9 @@
         }
     })
     export default class EditBudgetsDialog extends Vue {
-
-        @Action('saveIntermittentCriteriaDrivenBudget') saveIntermittentCriteriaDrivenBudgetAction: any;
-        @Action('setErrorMessage') setErrorMessageAction: any;
-
         @Prop() dialogData: EditBudgetsDialogData;
+
+        @Action('setErrorMessage') setErrorMessageAction: any;
 
         editBudgetsDialogGridHeaders: DataTableHeader[] = [
             {text: 'Budget', value: 'name', sortable: false, align: 'center', class: '', width: ''},
@@ -330,10 +328,6 @@
 
             if (!isNil(criteria)) {
                 this.editBudgetsDialogGridData[this.selectedCriteriaIndex].criteriaBudgets.criteria = criteria;
-
-                this.saveIntermittentCriteriaDrivenBudgetAction(
-                    {updateIntermittentCriteriaDrivenBudget: this.editBudgetsDialogGridData[this.selectedCriteriaIndex].criteriaBudgets}
-                );
                 this.selectedCriteriaIndex = -1;
             }
         }


### PR DESCRIPTION
-removed saveIntermittentCriteriaDrivenBudgetAction property & and action dispatch from EditBudgetsDialog component (no longer exists)
-removed unused properties budgetCriteriaHeaders & currencyInputConfig from InvestmentEditor component
-updated selectedInvestmentLibrary modification code for specified budgetYear inside onEditBudgetYearAmount function
-updated selectedInvestmentLibrary modification code inside onApplyToScenario function