### PR TITLE
vnext/617: Prevent analysis if committed project start < analysis start

### DIFF
--- a/BridgeCareApp/BridgeCare/Controllers/SimulationController.cs
+++ b/BridgeCareApp/BridgeCare/Controllers/SimulationController.cs
@@ -87,7 +87,7 @@ namespace BridgeCare.Controllers
         private Dictionary<string, SimulationRunMethod> CreateRunMethods()
         {
             Task<string> RunAnySimulation(SimulationModel model, UserInformationModel userInformation) =>
-                repo.RunSimulation(model);
+                repo.RunSimulation(model, db);
             Task<string> RunPermittedSimulation(SimulationModel model, UserInformationModel userInformation) =>
                 repo.RunPermittedSimulation(model, db, userInformation.Name);
 

--- a/BridgeCareApp/BridgeCare/DataAccessLayer/SimulationDAL.cs
+++ b/BridgeCareApp/BridgeCare/DataAccessLayer/SimulationDAL.cs
@@ -180,7 +180,7 @@ namespace BridgeCare.DataAccessLayer
         /// </summary>
         /// <param name="model">SimulationModel</param>
         /// <returns>string Task</returns>
-        public Task<string> RunSimulation(SimulationModel model)
+        public Task<string> RunSimulation(SimulationModel model, BridgeCareContext db)
         {
             if (model is null)
             {
@@ -189,6 +189,9 @@ namespace BridgeCare.DataAccessLayer
 
             try
             {
+                if (!db.Simulations.Any(s => s.SIMULATIONID == model.simulationId))
+                    throw new RowNotInTableException($"No scenario was found with id {model.simulationId}");
+
                 var connectionString = ConfigurationManager.ConnectionStrings["BridgeCareContext"].ConnectionString;
                 DBMgr.NativeConnectionParameters = new ConnectionParameters(connectionString, false, "MSSQL");
 
@@ -197,6 +200,25 @@ namespace BridgeCare.DataAccessLayer
 #else
                 var mongoConnection = Settings.Default.MongoDBProdConnectionString;
 #endif
+
+                var simulation = db.Simulations
+                    .Include(s => s.COMMITTEDPROJECTS)
+                    .Single(s => s.SIMULATIONID == model.simulationId);
+
+                if (simulation.COMMITTEDPROJECTS.Any())
+                {
+                    var earliestCommittedProjectStartYear = simulation.COMMITTEDPROJECTS
+                        .OrderBy(cp => cp.YEARS).First().YEARS;
+                    if (earliestCommittedProjectStartYear < simulation.COMMITTED_START)
+                    {
+                        var mongoClient = new MongoClient(mongoConnection);
+                        var mongoDB = mongoClient.GetDatabase("BridgeCare");
+                        var simulations = mongoDB.GetCollection<SimulationModel>("scenarios");
+                        var updateStatus = Builders<SimulationModel>.Update.Set("status", "Error: Projects committed before analysis start");
+                        simulations.UpdateOne(s => s.simulationId == model.simulationId, updateStatus);
+                        throw new ConstraintException("Analysis error: Projects committed before analysis start");
+                    }
+                }
 
                 var simulationParameters = new SimulationParameters(
                     model.simulationName,
@@ -223,7 +245,7 @@ namespace BridgeCare.DataAccessLayer
                 throw new RowNotInTableException($"No scenario was found with id {model.simulationId}");
             if (!db.Simulations.Include(s => s.USERS).First(s => s.SIMULATIONID == model.simulationId).UserCanModify(username))
                 throw new UnauthorizedAccessException("You are not authorized to run this scenario.");
-            return RunSimulation(model);
+            return RunSimulation(model, db);
         }
 
         /// <summary>

--- a/BridgeCareApp/BridgeCare/Interfaces/ISimulation.cs
+++ b/BridgeCareApp/BridgeCare/Interfaces/ISimulation.cs
@@ -14,7 +14,7 @@ namespace BridgeCare.Interfaces
         void UpdatePermittedSimulation(SimulationModel model, BridgeCareContext db, string username);
         void DeleteAnySimulation(int id, BridgeCareContext db);
         void DeletePermittedSimulation(int id, BridgeCareContext db, string username);
-        Task<string> RunSimulation(SimulationModel model);
+        Task<string> RunSimulation(SimulationModel model, BridgeCareContext db);
         Task<string> RunPermittedSimulation(SimulationModel model, BridgeCareContext db, string username);
         void SetSimulationLastRunDate(int id, BridgeCareContext db);
         void SetPermittedSimulationUsers(int simulationId, List<SimulationUserModel> simulationUsers, BridgeCareContext db, string username);


### PR DESCRIPTION
-added BridgeCareContext as a parameter to 'RunSimulation' function
-added select for simulation inside 'RunSimulation' to get a simulation with its committed projects
--added check for any committed projects on selected simulation
--added check for earliest committed project start year being less than the simulation analysis start
--added mongo db update for simulation status with message 'Error: Projects committed before analysis start' when earliest committed project start year is less than simulation analysis start
--throw constraint exception when earliest committed project start year is less than simulation analysis start