### PR TITLE
vnext/837: Allow Blank Priority Year

### DIFF
--- a/BridgeCareApp/VuejsApp/src/components/priority-editor/PriorityEditor.vue
+++ b/BridgeCareApp/VuejsApp/src/components/priority-editor/PriorityEditor.vue
@@ -50,17 +50,18 @@
                                         :return-value.sync="props.item[header.value]"
                                         @save="onEditPriorityProperty(props.item, header.value, props.item[header.value])"
                                         large lazy persistent>
-                                    <v-text-field readonly single-line class="sm-txt"
+                                    <v-text-field v-if="header.value === 'priorityLevel'" readonly single-line class="sm-txt"
                                                   :value="props.item[header.value]"
                                                   :rules="[rules['generalRules'].valueIsNotEmpty]"/>
+                                    <v-text-field v-else readonly single-line class="sm-txt"
+                                                  :value="props.item[header.value]"/>
                                     <template slot="input">
                                         <v-text-field v-if="header.value === 'priorityLevel'" label="Edit" single-line
                                                       v-model.number="props.item[header.value]"
                                                       :mask="'##########'"
                                                       :rules="[rules['generalRules'].valueIsNotEmpty]"/>
                                         <v-text-field v-else label="Edit" single-line :mask="'####'"
-                                                      v-model.number="props.item[header.value]"
-                                                      :rules="[rules['generalRules'].valueIsNotEmpty]"/>
+                                                      v-model.number="props.item[header.value]"/>
                                     </template>
                                 </v-edit-dialog>
                             </div>
@@ -109,7 +110,7 @@
                 </v-data-table>
             </div>
         </v-flex>
-        <v-flex v-show="hasSelectedPriorityLibrary && selectedPriorityLibrary.id !== stateScenarioPriorityLibrary.id"
+        <v-flex v-show="hasSelectedPriorityLibrary && selectedScenarioId === '0'"
                 xs12>
             <v-layout justify-center>
                 <v-flex xs6>
@@ -226,7 +227,7 @@
         prioritiesDataTableRows: PrioritiesDataTableRow[] = [];
         priorityDataTableHeaders: DataTableHeader[] = [
             {text: 'Priority', value: 'priorityLevel', align: 'left', sortable: false, class: '', width: ''},
-            {text: 'Year', value: 'year', align: 'left', sortable: false, class: '', width: ''},
+            {text: 'Year', value: 'year', align: 'left', sortable: false, class: '', width: '7%'},
             {text: 'Criteria', value: 'criteria', align: 'left', sortable: false, class: '', width: ''}
         ];
         selectedPriorityRows: PrioritiesDataTableRow[] = [];
@@ -626,8 +627,7 @@
                                 this.rules['generalRules'].valueIsWithinRange(pf.funding, [0, 100]);
                     });
 
-                    return this.rules['generalRules'].valueIsNotEmpty(p.priorityLevel) === true &&
-                            this.rules['generalRules'].valueIsNotEmpty(p.year) === true && allSubDataIsValid;
+                    return this.rules['generalRules'].valueIsNotEmpty(p.priorityLevel) === true && allSubDataIsValid;
                 });
 
                 if (this.selectedScenarioId !== '0') {

--- a/BridgeCareApp/VuejsApp/src/components/priority-editor/priority-editor-dialogs/CreatePriorityDialog.vue
+++ b/BridgeCareApp/VuejsApp/src/components/priority-editor/priority-editor-dialogs/CreatePriorityDialog.vue
@@ -11,7 +11,7 @@
                     <v-text-field label="Priority" outline v-model.number="newPriority.priorityLevel"
                                   :mask="'##########'" :rules="[rules['generalRules'].valueIsNotEmpty]"/>
                     <v-text-field label="Year" outline v-model.number="newPriority.year"
-                                    :mask="'####'" :rules="[rules['generalRules'].valueIsNotEmpty]"/>
+                                    :mask="'####'"/>
                 </v-layout>
             </v-card-text>
             <v-card-actions>


### PR DESCRIPTION
-removed validation requiring priority years to not be blank
-fixed textarea description for priority libraries being displayed even if there was a selected scenario (should only display when no scenario is selected)